### PR TITLE
Fix typo in suggests package asl3-asterisk-dev

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -101,7 +101,7 @@ Recommends:
  sox,
 Suggests:
  asl3-asterisk-dahdi,
- asl3-3asterisk-dev,
+ asl3-asterisk-dev,
  asl3-asterisk-doc,
 Description: Open Source Private Branch Exchange (PBX)
  Asterisk is an Open Source PBX and telephony toolkit.


### PR DESCRIPTION
Removing extra character in the package name.