### PR TITLE
Removing packages with files that overlap asterisk-modules

### DIFF
--- a/debian/asl3-asterisk-dahdi.install
+++ b/debian/asl3-asterisk-dahdi.install
@@ -1,3 +1,0 @@
-usr/lib/${DEB_HOST_MULTIARCH}/asterisk/modules/chan_dahdi.so
-usr/lib/${DEB_HOST_MULTIARCH}/asterisk/modules/codec_dahdi.so
-usr/lib/${DEB_HOST_MULTIARCH}/asterisk/modules/res_timing_dahdi.so

--- a/debian/asl3-asterisk-mp3.install
+++ b/debian/asl3-asterisk-mp3.install
@@ -1,1 +1,0 @@
-usr/lib/${DEB_HOST_MULTIARCH}/asterisk/modules/format_mp3.so

--- a/debian/asl3-asterisk-mysql.install
+++ b/debian/asl3-asterisk-mysql.install
@@ -1,1 +1,0 @@
-usr/lib/${DEB_HOST_MULTIARCH}/asterisk/modules/res_config_mysql.so

--- a/debian/asl3-asterisk-ooh323.install
+++ b/debian/asl3-asterisk-ooh323.install
@@ -1,1 +1,0 @@
-usr/lib/${DEB_HOST_MULTIARCH}/asterisk/modules/chan_ooh323.so

--- a/debian/control
+++ b/debian/control
@@ -100,7 +100,6 @@ Recommends:
  asterisk-moh-opsound-gsm,
  sox,
 Suggests:
- asl3-asterisk-dahdi,
  asl3-asterisk-dev,
  asl3-asterisk-doc,
 Description: Open Source Private Branch Exchange (PBX)
@@ -155,45 +154,6 @@ Description: loadable modules for the Asterisk PBX
  .
  This package includes most of the Asterisk loadable modules.
  There is normally no need to explicitly install it.
-
-Package: asl3-asterisk-dahdi
-Conflicts: asterisk-dahdi
-Architecture: linux-any
-Depends:
- asl3-asterisk (= ${binary:Version}),
- dahdi,
- ${misc:Depends},
- ${shlibs:Depends},
-Breaks:
- asterisk-modules (<< 1:11.6.0~dfsg-2),
-Replaces:
- asterisk-modules (<< 1:11.6.0~dfsg-2),
-Description: DAHDI devices support for the Asterisk PBX
- Asterisk is an Open Source PBX and telephony toolkit.
- .
- This package includes the DAHDI channel driver (chan_dahdi.so)
- and a number of other Asterisk modules that require DAHDI support.
- They will not be useful without kernel-level DAHDI support.
- .
- For more information about the Asterisk PBX,
- have a look at the Asterisk package.
-
-Package: asl3-asterisk-mysql
-Conflicts: asterisk-mysql
-Architecture: any
-Depends:
- asl3-asterisk (= ${binary:Version}),
- ${misc:Depends},
- ${shlibs:Depends},
-Description: MySQL database protocol support for the Asterisk PBX
- Asterisk is an Open Source PBX and telephony toolkit.
- .
- This package provides support for using a MySQL database
- to store configuration, call detail records,
- and also provides generic access to it from the dialplan.
- .
- For more information about the Asterisk PBX,
- have a look at the Asterisk package.
 
 Package: asl3-asterisk-tests
 Conflicts: asterisk-tests

--- a/debian/copyright_hints
+++ b/debian/copyright_hints
@@ -442,7 +442,6 @@ Files: BSDmakefile
  debian/asterisk-config.lintian-overrides
  debian/asterisk-config.postinst
  debian/asterisk-config.preinst
- debian/asterisk-dahdi.install
  debian/asterisk-dev.install
  debian/asterisk-dev.lintian-overrides
  debian/asterisk-dev.manpages
@@ -450,9 +449,6 @@ Files: BSDmakefile
  debian/asterisk-mobile.install
  debian/asterisk-modules.install
  debian/asterisk-modules.lintian-overrides
- debian/asterisk-mp3.install
- debian/asterisk-mysql.install
- debian/asterisk-ooh323.install
  debian/asterisk-tests.install
  debian/asterisk-tests.lintian-overrides
  debian/asterisk.default


### PR DESCRIPTION
Just doing some cleanup. Not sure why the debian source had these packages. They all contain files that are already contained in asterisk-modules, so they cannot be installed at the same time as asterisk-modules.
If we need to keep our packaging close to the "upstream" packaging, then I guess this PR could be rejected. But if we want to just maintain our own, I'm in favor of cleaning it up so there is less to maintain.