### PR TITLE
Obey user requested astersk version instead of using current.

### DIFF
--- a/build-tree
+++ b/build-tree
@@ -41,7 +41,7 @@ if [ -d ${LPATH} ]; then
 fi
 
 if [ ! -f asterisk-${AST_VER}.tar.gz ]; then
-	wget -O asterisk-${AST_VER}.tar.gz https://downloads.asterisk.org/pub/telephony/asterisk/asterisk-20-current.tar.gz
+	wget -O asterisk-${AST_VER}.tar.gz https://downloads.asterisk.org/pub/telephony/asterisk/releases/asterisk-${AST_VER}.tar.gz
 fi
 
 tar xfz asterisk-${AST_VER}.tar.gz


### PR DESCRIPTION
build-tree is now broken when using `-a 20.5.0` because pub/telephony/asterisk only contains the most recent release, which is 20.5.1, aliased as current. To actually use the correct asterisk version, get the package from pub/telephony/asterisk/releases