### PR TITLE
Turn on -e flag for build-tree, to stop on first error

### DIFF
--- a/build-tree
+++ b/build-tree
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 usage() { echo "Usage: $0 -a ASTERISK_VERSION -r RELEASE -v APP_RPT_VERSION" 1>&2; exit 1; }
 
 while getopts "a:r:v:" o; do


### PR DESCRIPTION
It probably doesn't make sent to try the subsequent steps if one of the build steps fails. The script should stop on the first error.