### PR TITLE
Patch [Asterisk] ast_variable_update() API to play nicely with templates

### DIFF
--- a/debian/patches/config_c_fix_template_writing.patch
+++ b/debian/patches/config_c_fix_template_writing.patch
@@ -1,0 +1,25 @@
+diff --git a/main/config.c b/main/config.c
+index e7ac4149a6..e81d3afced 100644
+--- a/main/config.c
++++ b/main/config.c
+@@ -1533,13 +1533,19 @@ int ast_variable_delete(struct ast_category *category, const char *variable, con
+ int ast_variable_update(struct ast_category *category, const char *variable,
+ 						const char *value, const char *match, unsigned int object)
+ {
+-	struct ast_variable *cur, *prev=NULL, *newer=NULL;
++	struct ast_variable *cur, *prev=NULL, *newer=NULL, *matchvar = NULL;
+ 
+ 	for (cur = category->root; cur; prev = cur, cur = cur->next) {
+ 		if (strcasecmp(cur->name, variable) ||
+ 			(!ast_strlen_zero(match) && strcasecmp(cur->value, match)))
+ 			continue;
++		matchvar = cur;
++	}
+ 
++	for (cur = category->root; cur; prev = cur, cur = cur->next) {
++		if (cur != matchvar) {
++			continue;
++		}
+ 		if (!(newer = ast_variable_new(variable, value, cur->file)))
+ 			return -1;
+ 

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -8,4 +8,5 @@
 2008_disable_ilbc.patch
 2010_astdatadir.patch
 config_c_fix_template_inheritance_overrides.patch
+config_c_fix_template_writing.patch
 sounds_ulaw_default


### PR DESCRIPTION
This "patch" addresses an issue with changes written to templated configuration files using Asterisk's ast_variable_update() API not being as expected.  The failures included values being added to (or not removed from) a [child] category even though the same value exists in the [parent] template.