### PR TITLE
Add new "build-asl3" script

### DIFF
--- a/add-app_rpt-modules
+++ b/add-app_rpt-modules
@@ -27,12 +27,12 @@ if [ -d apps/app_rpt ]; then
 fi
 
 if [ -d channels/xpmr ]; then
-	rm -rf channels/apmr
+	rm -rf channels/xpmr
 fi
 
 cp -r $APPRPT/apps/app_rpt* $APPRPT/apps/app_gps* apps/
 cp -r $APPRPT/channels/* channels/
-mkdir configs/asl3
+mkdir -p configs/asl3
 cp $APPRPT/configs/rpt/* configs/asl3/
 cp $APPRPT/include/asterisk/* include/asterisk/
 cp $APPRPT/res/* res/

--- a/build-asl3
+++ b/build-asl3
@@ -81,7 +81,8 @@ EPOCH="2"
 FULL_REL="${REL}.deb$(lsb_release -rs 2> /dev/null)"
 VSTR="${AST_VER}+asl3-${RPT_VER}"
 
-BASE_DIR="$(dirname $(pwd -P))"
+BASE_DIR="$(pwd -P)"
+BASE_DIR="${BASE_DIR%/asl3-asterisk}"
 ASL3_ASTERISK_DIR="${BASE_DIR}/asl3-asterisk"
 ASTERISK_DIR="${BASE_DIR}/asterisk"
 APP_RPT_DIR="${BASE_DIR}/app_rpt"
@@ -260,6 +261,18 @@ add_asl3-asterisk()
     fi
 }
 
+merge_asterisk()
+{
+    copy_path "${ASTERISK_DIR}" "${MERGE_DIR}"
+
+    pushd "${MERGE_DIR}"
+    rm -f menuselect.makedeps
+    rm -f menuselect.makeopts
+    rm -f menuselect-tree
+    rm -f build_tools/menuselect-deps
+    popd
+}
+
 merge_app_rpt()
 {
     pushd "${APP_RPT_DIR}"
@@ -312,7 +325,9 @@ create_build_directory()
     #
     # Create the merged build directory
     #
-    copy_path "${ASTERISK_DIR}" "${MERGE_DIR}"
+
+    echo "Add \"asterisk\""
+    merge_asterisk
 
     echo "Add \"app_rpt\" modules, apply patches"
     merge_app_rpt

--- a/build-asl3
+++ b/build-asl3
@@ -1,18 +1,22 @@
 #!/usr/bin/bash
 
+AST_VER=${AST_VER:-""}
+RPT_VER=${RPT_VER:-""}
+REL_VER=${REL_VER:-"1"}
+
 set -e
 
 usage()
 {
     cat <<_EOT_ 1>&2
-Usage : $0 -a ASTV -v RPTV -r RELV [-d DESTDIR] [-l] ACTIONS 
+Usage : $0 -a ASTV -v RPTV [-r RELV] [-d DESTDIR] [-l] ACTIONS 
 
 Required options :
-  -a  Asterisk version    (e.g. 20.9.2)
-  -v  ASL/app_rpt version (e.g. 3.0.4)
-  -r  Release version     (e.g. 1)
+  -a  Asterisk version        (e.g. 20.9.2)
+  -v  ASL/app_rpt version     (e.g. 3.0.4)
 
 Optional options :
+  -r  Release version         (default: 1)
   -d  local install directory (default: "/")
   -l  Create merged source directory with symlinks
 
@@ -23,8 +27,11 @@ Actions (specify one or more) :
   install - "install" the build results, locally
   package - create Debian packages
 
-Note: specifying "build", "install", or "package" will, if needed, create
-the merged source directory.
+Note: specifying the "build", "install", or "package" actions will, if needed,
+create the merged source directory.
+
+Note: you can use the "AST_VER", "RPT_VER", and "REL_VER" environment variables
+to specify the Asterisk, ASL/app_rpt, and Release versions.
 _EOT_
     exit 1
 }
@@ -176,7 +183,7 @@ link_path()
     if [[ -f "$src_path" ]]; then
 	path=$(basename $src_path)
 	rel_dir=$(realpath --relative-to="$(dirname "$dst_path")" "$(dirname $src_path)")
-	ln -s "$rel_dir/$path" "$dst_path"
+	ln -f -s "$rel_dir/$path" "$dst_path"
     else
 	mkdir -p "${dst_path}"
 	( cd "$src_path" ; find . -mindepth 1 -path ".git" -prune -o -print )	\
@@ -186,7 +193,7 @@ link_path()
 	    if [[ -d "$src_path/$path" ]]; then
 		mkdir -p "$dst_path/$path"
 	    else
-		ln -s "$rel_dir/$path" "$dst_path/$path"
+		ln -f -s "$rel_dir/$path" "$dst_path/$path"
 	    fi
         done
     fi
@@ -300,8 +307,6 @@ create_build_directory()
 	# (note: the build dependencies have already been installed)
 	#
 	echo "Re-creating merged source directory (${MERGE_DIR})"
-	mv ${MERGE_DIR} ${MERGE_DIR}-REMOVE
-	sudo rm -rf ${MERGE_DIR}-REMOVE &
     fi
 
     #
@@ -320,7 +325,7 @@ create_build_directory()
     echo "Add version"
     rm -rf .version
     echo "${VSTR}" > .version
-    ( cd ChangeLogs && ln -s ChangeLog-${AST_VER}.md ChangeLog-${VSTR}.md5 )
+    ( cd ChangeLogs && ln -f -s ChangeLog-${AST_VER}.md ChangeLog-${VSTR}.md5 )
     rm debian/changelog
     debchange				\
 	--create			\
@@ -399,10 +404,8 @@ do_install()
     pushd "${MERGE_DIR}"
 
     echo "Installing (locally)"
-set -x
     sudo make install DESTDIR="${DESTDIR}"
     RC=$?
-set +x
     if [[ $RC -ne 0 ]]; then
 	echo "make install failed (exit code $RC)."	1>&2
 	exit 1

--- a/build-asl3
+++ b/build-asl3
@@ -5,7 +5,7 @@ set -e
 usage()
 {
     cat <<_EOT_ 1>&2
-Usage : $0 -a ASTV -v RPTV [-r RELV] [-d DESTDIR] [-l] ACTIONS 
+Usage : $0 -a ASTV -v RPTV -r RELV [-d DESTDIR] [-l] ACTIONS 
 
 Required options :
   -a  Asterisk version    (e.g. 20.9.2)

--- a/build-asl3
+++ b/build-asl3
@@ -163,14 +163,36 @@ copy_path()
     src_path="$1"
     dst_path="$2"
 
-    echo "Copy \"${src_path}\" to \"${dst_path}\""
-
     if [[ -f "$src_path" ]]; then
+	echo "Copy \"$src_path/$path\" --> \"$dst_path/$path\""
 	cp -p "${src_path}" "${dst_path}"
     else
-	mkdir -p "${dst_path}"
-	tar --create --directory="${src_path}" --file=- .	\
-	| tar --extract --directory="${dst_path}" --file=-
+	( cd "$src_path" ; find . -path ".git" -prune -o -print )	\
+	| while read -r path; do
+	    path="${path#./}"
+	    if [[ -d "$src_path/$path" ]]; then
+		if [[ ! -d "$dst_path/$path" ]]; then
+		    echo "Copy \"$src_path/$path\" --> \"$dst_path/$path\""
+		    mkdir -p "$dst_path/$path"
+		    tar --create --directory="${src_path}" --file=- .	\
+		    | tar --extract --directory="${dst_path}" --file=-
+		fi
+	    elif [[ -f "$src_path/$path" ]]; then
+		if [[ -f "$dst_path/$path" ]]; then
+		    if [ "$(stat -c %Y "$src_path/$path")" -gt "$(stat -c %Y "$dst_path/$path")" ]; then
+			echo "Update \"$src_path/$path\" --> \"$dst_path/$path\""
+			cp -p "$src_path/$path" "$dst_path/$path"
+		    fi
+		else
+		    echo "Add \"$src_path/$path\" --> \"$dst_path/$path\""
+		    cp -p "$src_path/$path" "$dst_path/$path"
+		fi
+	    else
+		echo "???? \"$src_path/$path\""
+		ls -ld $src_path/$path
+	    fi
+        done
+
     fi
 }
 
@@ -202,11 +224,11 @@ link_path()
 
 # ---------- ---------- ---------- ---------- ---------- ----------
 
-check_patched_files()
+prepare_patched_files()
 {
     patch="$1"
 
-    for file in $(grep -E '^--- |^\+\+\+ ' $patch | cut -d' ' -f2 | sed 's|^a/||;s|^b/||'); do
+    for file in $(grep -E '^--- |^\+\+\+ ' $patch | cut -d' ' -f2 | sed 's|^a/||;s|^b/||' | sort -u); do
 	if [[ -L "$file" ]]; then
 	    echo "replacing symlink'd file: $file"
 	    cp -p $file $file-ORIG
@@ -220,17 +242,37 @@ apply_patch()
     patch="$1"
 
     if [[ $USE_SYMLINKS -ne 0 ]]; then
-	check_patched_files "${patch}"
+	prepare_patched_files "${patch}"
     fi
+    echo "info: applying patch: $patch"
     patch -p1 < "${patch}"
-#   rm "${patch}"
 }
 
 prepare_patch_series()
 {
     for patch in $(cat debian/patches/series); do
-	check_patched_files "debian/patches/$patch"
+	prepare_patched_files "debian/patches/$patch"
     done
+}
+
+revert_patch()
+{
+    patch="$1"
+
+    if [[ ! -f "${patch}" ]]; then
+	return
+    fi
+
+    # check that all of the files being updated are regular files (and not symlinks)
+    for file in $(grep -E '^--- |^\+\+\+ ' $patch | cut -d' ' -f2 | sed 's|^a/||;s|^b/||' | sort -u); do
+	if [[ -L "$file" ]]; then
+	    echo "not reverting patch: $patch (can't patch a symlink: $file)"
+	    return
+	fi
+    done
+
+    echo "info: unapplying patch: $patch"
+    patch -p1 -R < "${patch}"
 }
 
 # ---------- ---------- ---------- ---------- ---------- ----------
@@ -263,18 +305,27 @@ add_asl3-asterisk()
 
 merge_asterisk()
 {
-    copy_path "${ASTERISK_DIR}" "${MERGE_DIR}"
+    if [[ -f "${MERGE_DIR}/.BEFORE-BUILD-APPLIED" ]]; then
+	# Revert "asterisk" patches
+	pushd "${MERGE_DIR}"
+	dpkg-source --after-build .
+	rm -f .BEFORE-BUILD-APPLIED
+	popd
+    fi
 
-    pushd "${MERGE_DIR}"
-    rm -f menuselect.makedeps
-    rm -f menuselect.makeopts
-    rm -f menuselect-tree
-    rm -f build_tools/menuselect-deps
-    popd
+    copy_path "${ASTERISK_DIR}"		"${MERGE_DIR}"
 }
 
 merge_app_rpt()
 {
+    if [[ -d "${MERGE_DIR}" ]]; then
+	pushd "${MERGE_DIR}"
+	revert_patch Makefiles.diff
+	revert_patch res/Makefile.diff
+	revert_patch utils/Makefile.diff
+	popd
+    fi
+
     pushd "${APP_RPT_DIR}"
     copy_path "Makefiles.diff"		"${MERGE_DIR}/Makefiles.diff"
     copy_path "apps"			"${MERGE_DIR}/apps"
@@ -359,6 +410,7 @@ create_build_directory()
 
     echo "Prepare source for building, apply patches"
     dpkg-source --before-build .
+    touch .BEFORE-BUILD-APPLIED
 
     popd
 }

--- a/build-asl3
+++ b/build-asl3
@@ -1,22 +1,36 @@
 #!/usr/bin/bash
 
-AST_VER=${AST_VER:-""}
-RPT_VER=${RPT_VER:-""}
-REL_VER=${REL_VER:-"1"}
-
 set -e
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+# Get the default Asterisk + app_rpt versions from newest package version
+ASL_PKG_INFO=$(apt-cache show asl3-asterisk	2>/dev/null	\
+	       | grep Version					\
+	       | head -1					\
+	      )
+ASL_PKG_INFO="${ASL_PKG_INFO#Version: *:}"
+AST_PKG="${ASL_PKG_INFO%+*}"
+ASL_PKG_INFO="${ASL_PKG_INFO#${AST_PKG}+asl3-}"
+RPT_PKG="${ASL_PKG_INFO%-*}"
+ASL_PKG_INFO="${ASL_PKG_INFO#${RPT_PKG}-}"
+REL_PKG="${ASL_PKG_INFO%.deb*}"
+
+AST_VER="${AST_VER:-$AST_PKG}"
+RPT_VER="${RPT_VER:-$RPT_PKG}"
+REL_VER="${REL_VER:-$REL_PKG}"
+
+# ---------- ---------- ---------- ---------- ---------- ----------
 
 usage()
 {
     cat <<_EOT_ 1>&2
-Usage : $0 -a ASTV -v RPTV [-r RELV] [-d DESTDIR] [-l] ACTIONS 
+Usage : $0 [-a ASTV] [-v RPTV] [-r RELV] [-d DESTDIR] [-l] ACTIONS 
 
-Required options :
+Options :
   -a  Asterisk version        (e.g. 20.9.2)
   -v  ASL/app_rpt version     (e.g. 3.0.4)
-
-Optional options :
-  -r  Release version         (default: 1)
+  -r  Release version         (e.g. 1)
   -d  local install directory (default: "/")
   -l  Create merged source directory with symlinks
 
@@ -30,15 +44,18 @@ Actions (specify one or more) :
 Note: specifying the "build", "install", or "package" actions will, if needed,
 create the merged source directory.
 
-Note: you can use the "AST_VER", "RPT_VER", and "REL_VER" environment variables
-to specify the Asterisk, ASL/app_rpt, and Release versions.
+Note: the Asterisk, ASL/app_rpt, and Release versions will default to those
+of the "asl3-asterisk" package.  You can also use the "AST_VER", "RPT_VER",
+and "REL_VER" environment variables to specify the versions.
 _EOT_
     exit 1
 }
 
+# ---------- ---------- ---------- ---------- ---------- ----------
+
 DESTDIR=${DESTDIR:-"/"}
 EDITOR=${EDITOR:-${ALT_EDIT:-vim}}
-EMAIL=${EMAIL:-"builder@allstarlink.org"}
+export EMAIL=${EMAIL:-"builder@allstarlink.org"}
 USE_SYMLINKS=0
 
 while getopts "a:d:lr:v:" o; do
@@ -50,7 +67,7 @@ while getopts "a:d:lr:v:" o; do
 	DESTDIR=${OPTARG}
 	;;
     "r" )
-	REL=${OPTARG}
+	REL_VER=${OPTARG}
 	;;
     "v" )
 	RPT_VER=${OPTARG}
@@ -60,7 +77,7 @@ while getopts "a:d:lr:v:" o; do
 	;;
     * )
 	echo "***"				1>&2
-	echo "*** unrecognized option \"${o}\""	1>&2
+	echo "*** Unrecognized option \"${o}\""	1>&2
 	echo "***"				1>&2
 	echo ""					1>&2
 	usage
@@ -69,16 +86,16 @@ while getopts "a:d:lr:v:" o; do
 done
 shift $((OPTIND-1))
 
-if [ -z "${AST_VER}" ] || [ -z "${RPT_VER}" ] || [ -z "${REL}" ]; then
+if [[ -z "${AST_VER}" || -z "${RPT_VER}" || -z "${REL_VER}" ]]; then
     echo "***"					1>&2
-    echo "*** version(s) not specified"		1>&2
+    echo "*** Version(s) not specified"		1>&2
     echo "***"					1>&2
     echo ""					1>&2
     usage
 fi
 
 EPOCH="2"
-FULL_REL="${REL}.deb$(lsb_release -rs 2> /dev/null)"
+FULL_REL="${REL_VER}.deb$(lsb_release -rs 2> /dev/null)"
 VSTR="${AST_VER}+asl3-${RPT_VER}"
 
 BASE_DIR="$(pwd -P)"
@@ -96,7 +113,7 @@ DO_PACKAGE=0
 
 if [[ $# -eq 0 ]]; then
     echo "***"					1>&2
-    echo "*** no action(s) specified"		1>&2
+    echo "*** No action(s) specified"		1>&2
     echo "***"					1>&2
     echo ""					1>&2
     usage
@@ -133,7 +150,7 @@ while [ $# -gt 0 ]; do
 	fi
 	if [[ $USE_SYMLINKS -ne 0 || -L "${MERGE_DIR}/README.md" ]]; then
 	    echo "***"							1>&2
-	    echo "*** can't create packages with symlink'd source"	1>&2
+	    echo "*** Can't create packages with symlink'd source"	1>&2
 	    echo "***"							1>&2
 	    exit 1
 	fi

--- a/build-asl3
+++ b/build-asl3
@@ -1,0 +1,454 @@
+#!/usr/bin/bash
+
+set -e
+
+usage()
+{
+    cat <<_EOT_ 1>&2
+Usage : $0 -a ASTV -v RPTV [-r RELV] [-d DESTDIR] [-l] ACTIONS 
+
+Required options :
+  -a  Asterisk version    (e.g. 20.9.2)
+  -v  ASL/app_rpt version (e.g. 3.0.4)
+  -r  Release version     (e.g. 1)
+
+Optional options :
+  -d  local install directory (default: "/")
+  -l  Create merged source directory with symlinks
+
+Actions (specify one or more) :
+  source  - create the merged source directory
+  clean   - "clean" the merged source directory
+  build   - "build" the source code
+  install - "install" the build results, locally
+  package - create Debian packages
+
+Note: specifying "build", "install", or "package" will, if needed, create
+the merged source directory.
+_EOT_
+    exit 1
+}
+
+DESTDIR=${DESTDIR:-"/"}
+EDITOR=${EDITOR:-${ALT_EDIT:-vim}}
+EMAIL=${EMAIL:-"builder@allstarlink.org"}
+USE_SYMLINKS=0
+
+while getopts "a:d:lr:v:" o; do
+    case "${o}" in
+    "a" )
+	AST_VER=${OPTARG}
+	;;
+    "d" )
+	DESTDIR=${OPTARG}
+	;;
+    "r" )
+	REL=${OPTARG}
+	;;
+    "v" )
+	RPT_VER=${OPTARG}
+	;;
+    "l" )
+	USE_SYMLINKS=1
+	;;
+    * )
+	echo "***"				1>&2
+	echo "*** unrecognized option \"${o}\""	1>&2
+	echo "***"				1>&2
+	echo ""					1>&2
+	usage
+	;;
+    esac
+done
+shift $((OPTIND-1))
+
+if [ -z "${AST_VER}" ] || [ -z "${RPT_VER}" ] || [ -z "${REL}" ]; then
+    echo "***"					1>&2
+    echo "*** version(s) not specified"		1>&2
+    echo "***"					1>&2
+    echo ""					1>&2
+    usage
+fi
+
+EPOCH="2"
+FULL_REL="${REL}.deb$(lsb_release -rs 2> /dev/null)"
+VSTR="${AST_VER}+asl3-${RPT_VER}"
+
+BASE_DIR="$(dirname $(pwd -P))"
+ASL3_ASTERISK_DIR="${BASE_DIR}/asl3-asterisk"
+ASTERISK_DIR="${BASE_DIR}/asterisk"
+APP_RPT_DIR="${BASE_DIR}/app_rpt"
+MERGE_DIR="${BASE_DIR}/asl3-asterisk-${VSTR}"
+
+DO_SOURCE=0
+DO_CLEAN=0
+DO_BUILD=0
+DO_INSTALL=0
+DO_PACKAGE=0
+
+if [[ $# -eq 0 ]]; then
+    echo "***"					1>&2
+    echo "*** no action(s) specified"		1>&2
+    echo "***"					1>&2
+    echo ""					1>&2
+    usage
+fi
+
+while [ $# -gt 0 ]; do
+    case "${1}" in
+    "source" )
+	DO_SOURCE=1
+	;;
+    "clean" )
+	DO_CLEAN=1
+	;;
+    "build" )
+	if [[ ! -d "${MERGE_DIR}" ]]; then
+	    DO_SOURCE=1
+	fi
+	DO_BUILD=1
+	;;
+    "install" )
+	if [[ ! -d "${MERGE_DIR}" ]]; then
+	    DO_SOURCE=1
+	fi
+	if [[ $DO_SOURCE -gt 0 ]]; then
+	    DO_BUILD=1
+	elif [[ ! -x "${MERGE_DIR}/main/asterisk" ]]; then
+	    DO_BUILD=1
+	fi
+	DO_INSTALL=1
+	;;
+    "package" )
+	if [[ ! -d "${MERGE_DIR}" ]]; then
+	    DO_SOURCE=1
+	fi
+	if [[ $USE_SYMLINKS -ne 0 || -L "${MERGE_DIR}/README.md" ]]; then
+	    echo "***"							1>&2
+	    echo "*** can't create packages with symlink'd source"	1>&2
+	    echo "***"							1>&2
+	    exit 1
+	fi
+	if [[ $DO_SOURCE -gt 0 ]]; then
+	    DO_BUILD=1
+	elif [[ ! -x "${MERGE_DIR}/main/asterisk" ]]; then
+	    DO_BUILD=1
+	fi
+	DO_PACKAGE=1
+	;;
+    * )
+	usage
+	;;
+    esac
+    shift
+done
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+copy_path()
+{
+    if [[ $USE_SYMLINKS -ne 0 ]]; then
+	link_path "$1" "$2"
+	return
+    fi
+
+    src_path="$1"
+    dst_path="$2"
+
+    echo "Copy \"${src_path}\" to \"${dst_path}\""
+
+    if [[ -f "$src_path" ]]; then
+	cp -p "${src_path}" "${dst_path}"
+    else
+	mkdir -p "${dst_path}"
+	tar --create --directory="${src_path}" --file=- .	\
+	| tar --extract --directory="${dst_path}" --file=-
+    fi
+}
+
+link_path()
+{
+    src_path="$1"
+    dst_path="$2"
+
+    echo "Link \"${src_path}\" to \"${dst_path}\""
+
+    if [[ -f "$src_path" ]]; then
+	path=$(basename $src_path)
+	rel_dir=$(realpath --relative-to="$(dirname "$dst_path")" "$(dirname $src_path)")
+	ln -s "$rel_dir/$path" "$dst_path"
+    else
+	mkdir -p "${dst_path}"
+	( cd "$src_path" ; find . -mindepth 1 -path ".git" -prune -o -print )	\
+	| while read -r path; do
+	    path="${path#./}"
+	    rel_dir=$(realpath --relative-to="$(dirname "$dst_path/$path")" "$src_path")
+	    if [[ -d "$src_path/$path" ]]; then
+		mkdir -p "$dst_path/$path"
+	    else
+		ln -s "$rel_dir/$path" "$dst_path/$path"
+	    fi
+        done
+    fi
+}
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+check_patched_files()
+{
+    patch="$1"
+
+    for file in $(grep -E '^--- |^\+\+\+ ' $patch | cut -d' ' -f2 | sed 's|^a/||;s|^b/||'); do
+	if [[ -L "$file" ]]; then
+	    echo "replacing symlink'd file: $file"
+	    cp -p $file $file-ORIG
+	    mv $file-ORIG $file
+	fi
+    done
+}
+
+apply_patch()
+{
+    patch="$1"
+
+    if [[ $USE_SYMLINKS -ne 0 ]]; then
+	check_patched_files "${patch}"
+    fi
+    patch -p1 < "${patch}"
+#   rm "${patch}"
+}
+
+prepare_patch_series()
+{
+    for patch in $(cat debian/patches/series); do
+	check_patched_files "debian/patches/$patch"
+    done
+}
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+add_asterisk()
+{
+    if [[ ! -d "${ASTERISK_DIR}" ]]; then
+	echo "Cloning \"asterisk\", tag==${AST_VER}"
+	git clone https://github.com/asterisk/asterisk.git "${ASTERISK_DIR}"
+	( cd "${ASTERISK_DIR}"; git checkout $AST_VER )
+    fi
+}
+
+add_app_rpt()
+{
+    if [[ ! -d "${APP_RPT_DIR}" ]]; then
+	echo "Cloning \"app_rpt\""
+	git clone https://github.com/AllStarLink/app_rpt.git "${APP_RPT_DIR}"
+#	( cd "${APP_RPT_DIR}"; git checkout $RPT_VER )
+    fi
+}
+
+add_asl3-asterisk()
+{
+    if [[ ! -d "${ASL3_ASTERISK_DIR}" ]]; then
+	echo "Cloning \"asl3-asterisk\""
+	git clone https://github.com/AllStarLink/asl3-asterisk.git "${ASL3_ASTERISK_DIR}"
+    fi
+}
+
+merge_app_rpt()
+{
+    pushd "${APP_RPT_DIR}"
+    copy_path "Makefiles.diff"		"${MERGE_DIR}/Makefiles.diff"
+    copy_path "apps"			"${MERGE_DIR}/apps"
+    copy_path "channels"		"${MERGE_DIR}/channels"
+    copy_path "configs/rpt"		"${MERGE_DIR}/configs/asl3"
+    copy_path "include"			"${MERGE_DIR}/include"
+    copy_path "res"			"${MERGE_DIR}/res"
+    copy_path "utils"			"${MERGE_DIR}/utils"
+    popd
+
+    pushd "${MERGE_DIR}"
+    apply_patch Makefiles.diff
+    apply_patch res/Makefile.diff
+    apply_patch utils/Makefile.diff
+    popd
+}
+
+merge_asl3_asterisk()
+{
+    pushd "${ASL3_ASTERISK_DIR}"
+    copy_path "debian"			"${MERGE_DIR}/debian"
+    copy_path "rpt-sounds"		"${MERGE_DIR}/rpt-sounds"
+    copy_path "etc"			"${MERGE_DIR}/etc"
+    popd
+}
+
+create_build_directory()
+{
+    if [[ ! -d "${MERGE_DIR}" ]]; then
+	#
+	# Make sure we have all of the build dependencies
+	#
+	echo "Installing build dependencies"
+	sudo "${ASL3_ASTERISK_DIR}/install-build-deps"
+
+	#
+	# Create the merged build directory
+	#
+	echo "Creating merged source directory (${MERGE_DIR})"
+    else
+	#
+	# Re-create the merged build directory
+	# (note: the build dependencies have already been installed)
+	#
+	echo "Re-creating merged source directory (${MERGE_DIR})"
+	mv ${MERGE_DIR} ${MERGE_DIR}-REMOVE
+	sudo rm -rf ${MERGE_DIR}-REMOVE &
+    fi
+
+    #
+    # Create the merged build directory
+    #
+    copy_path "${ASTERISK_DIR}" "${MERGE_DIR}"
+
+    echo "Add \"app_rpt\" modules, apply patches"
+    merge_app_rpt
+
+    echo "Add \"debian\", \"rpt-sounds\""
+    merge_asl3_asterisk
+
+    pushd "${MERGE_DIR}"
+
+    echo "Add version"
+    rm -rf .version
+    echo "${VSTR}" > .version
+    ( cd ChangeLogs && ln -s ChangeLog-${AST_VER}.md ChangeLog-${VSTR}.md5 )
+    rm debian/changelog
+    debchange				\
+	--create			\
+	--package asl3-asterisk 	\
+	-v ${EPOCH}:${VSTR}-${FULL_REL}	\
+	--				\
+	"see https://github.com/AllStarLink/app_rpt"
+    debchange				\
+	--release			\
+	""
+
+    if [[ $USE_SYMLINKS -ne 0 ]]; then
+	echo "Prepare to-be-patched files"
+	prepare_patch_series
+    fi
+
+    echo "Prepare source for building, apply patches"
+    dpkg-source --before-build .
+
+    popd
+}
+
+do_source()
+{
+    # Make sure that we have a copy of the "asterisk" repo
+    add_asterisk
+
+    # Make sure that we have a copy of the "app_rpt" repo
+    add_app_rpt
+
+    # Make sure that we have a copy of the "asl3-asterisk" repo
+    add_asl3-asterisk
+
+    # Create our merged build directory
+    create_build_directory
+}
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+do_clean()
+{
+    pushd "${MERGE_DIR}"
+
+    echo "Clean (after building/packaging)"
+    dh clean
+    RC=$?
+    if [[ $RC -ne 0 ]]; then
+	echo "dh clean failed (exit code $RC)."		1>&2
+	exit 1
+    fi
+
+    popd
+}
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+do_build()
+{
+    pushd "${MERGE_DIR}"
+
+    echo "Build"
+    dh build -j$(nproc --all)
+    RC=$?
+    if [[ $RC -ne 0 ]]; then
+	echo "dh build failed (exit code $RC)."		1>&2
+	exit 1
+    fi
+
+    popd
+}
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+do_install()
+{
+    pushd "${MERGE_DIR}"
+
+    echo "Installing (locally)"
+set -x
+    sudo make install DESTDIR="${DESTDIR}"
+    RC=$?
+set +x
+    if [[ $RC -ne 0 ]]; then
+	echo "make install failed (exit code $RC)."	1>&2
+	exit 1
+    fi
+
+    popd
+}
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+do_package()
+{
+    pushd "${MERGE_DIR}"
+
+    echo "Create the [debian] package"
+    fakeroot dh binary -j$(nproc --all)
+    RC=$?
+    if [[ $RC -ne 0 ]]; then
+	echo "dh binary failed (exit code $RC)."	1>&2
+	exit 1
+    fi
+
+    popd
+}
+
+# ---------- ---------- ---------- ---------- ---------- ----------
+
+if [[ $DO_SOURCE -gt 0 ]]; then
+    do_source
+fi
+
+if [[ $DO_CLEAN -gt 0 ]]; then
+    if [[ -d "${MERGE_DIR}" ]]; then
+        do_clean
+    fi
+fi
+
+if [[ $DO_BUILD -gt 0 ]]; then
+    do_build
+fi
+
+if [[ $DO_INSTALL -gt 0 ]]; then
+    do_install
+fi
+
+if [[ $DO_PACKAGE -gt 0 ]]; then
+    do_package
+fi
+

--- a/build-asl3.1.md
+++ b/build-asl3.1.md
@@ -1,0 +1,174 @@
+% build-asl3(1) ASL3 @@HEAD-DEVELOP@@
+% Allan Nathanson
+% August 2024
+
+# NAME
+
+build-asl3 - Build ASL3 Asterisk + app_rpt
+
+# SYNOPSIS
+
+Usage: `build-asl3 -a ASTV -v RPTV [-r RELV] [-d DESTDIR] [-l] ACTIONS`
+
+Required options :
+
+* -a  Asterisk version    (e.g. 20.9.2)
+* -v  ASL/app_rpt version (e.g. 3.0.4)
+
+Optional options :
+
+* -r  Release version (default: 1)
+* -d  local install directory (default: "/")
+* -l  Create merged source directory with symlinks
+
+Actions (specify one or more) :
+
+* source  - create the merged source directory
+* clean   - "clean" the merged source directory
+* build   - "build" the source code
+* install - "install" the build results, locally
+* package - create Debian packages
+
+Note: specifying the **build**, **install**, or **package** actions will, if needed, create the merged source directory.
+
+Note: you can use the **AST\_VER**, **RPT\_VER**, and **REL\_VER** environment variables to specify the Asterisk, ASL/app_rpt, and Release versions.
+
+# DESCRIPTION
+
+ASL3 Asterisk + app_rpt includes multiple source code projects including [Asterisk](https://github.com/asterisk/asterisk.git), [app_rpt](https://github.com/AllStarLink/app_rpt.git), and [asl3-asterisk](https://github.com/AllStarLink/asl3-asterisk.git).
+
+The command supports 2 different (but related) workflows :
+
+1. Building Debian packages (asl3-asterisk-*)
+2. Software development
+
+## DIRECTORY HIERARCHY
+
+When using the `build-asl3` command your system works with the following directory hierarchy :
+
+```
+<base directory>
+  asl3-asterisk-AST_VER+asl3-ASL_VER
+  asterisk
+  app_rpt
+  asl3-asterisk
+```
+
+The "asterisk", "app\_rpt", and "asl3-asterisk" directories contain the source code used to build ASL3 asterisk + app\_rpt.  The `build-asl3` script merges these 3 projects together into a single source directory, "asl3-asterisk-AST\_VER+asl3-ASL\_VER", that is used for building.
+
+Any Debian packages created by `build-asl3` will also be stored in the "\<base directory>".
+
+## WORKFLOW ACTIONS
+
+Each workflow uses a subset of "actions".
+
+### Action : **source**
+
+The **source** action ensures that copies of the "asterisk", "app\_rpt", and "asl3-asterisk" projects are available on your system.  If the source code for any of these projects is not available it will be downloaded from the GitHub repository.  If the source code is already available it will be used as-is (including any source code changes you have made).
+
+This action merges the "asterisk", "app\_rpt", and "asl3-asterisk" directories into the merged source directory.  If the merged directory already exists then its contents will be replaced.  If the directory does not exist it will be created.
+
+This action also ensures that any [Debian] project dependencies needed for building ASL3 have been installed on the system.
+
+Note: if you make any changes to the "asterisk", "app\_rpt", or "asl3-asterisk" directories you will need to repeat the **source** action to ensure that the merged directory includes those changes.
+
+### Action : **build**
+
+The **build** action compiles the source code in the merged directory.
+
+### Action : **install**
+
+The **install** action performs a "make install DESTDIR=/" in the merged directory.
+
+Note: this action does **NOT** include everything in the "asl3-asterisk-*" packages.  The focus is on executables (e.g. asterisk) and modules (e.g. app_rpt.so, chan_simpleusb.so, etc).  The assumption we have made is that you are working on software (code) changes and you wish to test them on a system that already has ASL3 installed.
+
+### Action : **package**
+
+The **package** action creates the Debian "asl3-asterisk-*" packages.
+
+### Action : **clean**
+
+The **clean** action performs the equivalent of a "make clean" in the merged directory.
+
+## TYPICAL WORKFLOWS
+
+### Building Debian packages (asl3-asterisk-*)
+
+This one's easy.  To build the "asl3-asterisk-*" Debian packages you can use the following command : 
+
+```
+git clone https://github.com/AllStarLink/asl3-asterisk.git  (if needed)
+cd asl3-asterisk
+./build-asl3 -a 20.9.2 -v 3.0.4 -r 1 source build package
+```
+
+Note: the `build-asl3` script is smart.  If the merged directory does not exist you can leave off the "source" and "build" actions (they will be automatically added).
+
+### Software development
+
+The following is an example of how you might use the `build-asl3` command to make a code change.
+
+1. To start, you will want to grab a copy of the asl3-asterisk project (we need the "build-asl3" command).
+
+	```
+git clone https://github.com/AllStarLink/asl3-asterisk.git
+```
+
+2.  Optionally, you can [pre-]fetch a copy of the "asterisk" project and checkout the "tag" of the version you wish to use.  If you skip this step (and that's OK) we will download a copy of the "asterisk" source code.
+
+	```
+git clone https://github.com/asterisk/asterisk.git
+(cd asterisk; git checkout 20.9.2)
+```
+
+3. Optionally, you can [pre-]fetch a copy of the "app\_rpt" project.  As above, if you wish to work with a specific version of "app\_rpt" then checkout it's "tag".   If you skip this step (and that's OK) we will download a copy of the "app\_rpt" source code.
+
+	```
+git clone https://github.com/AllStarLink/app_rpt.git
+(cd app_rpt; git checkout 3.0.4)     <-- optional
+```
+
+4. Create (or update) the merged source directory.
+
+	```
+	cd asl3-asterisk
+	./build-asl3 -a 20.9.2 -v 3.0.4 -r 1 source
+	```
+
+5. Build the sources in the merged source directory.
+
+	```
+	cd asl3-asterisk
+	./build-asl3 -a 20.9.2 -v 3.0.4 -r 1 build
+	```
+
+6. Install (and test) your changes.
+
+	```
+	cd asl3-asterisk
+	./build-asl3 -a 20.9.2 -v 3.0.4 -r 1 install
+	```
+
+7. Making iterative changes
+
+	If you need to make changes to your source code, make the updates in the "asterisk", "app\_rpt", and "asl3-asterisk" directories.  Then, repeat step 4 (update the source), step 5 (build), and step 6 (install/test).
+
+### Experimental Development
+
+The `build-asl3` command usage includes a "-l" option that, for now, should be considered "experimental" due to it's limited testing.
+This option changes how the "asterisk", "app\_rpt", and "asl3-asterisk" directories are merged together.
+Rather than copying each file to the merged directory the command will, instead, symlink the files back to the source directories.
+What this means is that you can make changes in the source directories and not need to re-exec `build-asl3` with the "source" action.
+
+Note: some of the files in the merged directory are patched.  If you are making source code changes to any of these [patched] files then you should not use the "-l" option.
+
+Note: the "-l" option can NOT be used when creating Debian packages.
+
+# BUGS
+
+Report bugs to https://github.com/AllStarLink/ASL3/issues
+
+# COPYRIGHT
+
+Copyright (C) 2024 Allan Nathanson and AllStarLink
+under the terms of the AGPL v3.

--- a/build-asl3.1.md
+++ b/build-asl3.1.md
@@ -80,7 +80,7 @@ The **build** action compiles the source code in the merged directory.
 
 The **install** action performs a "make install DESTDIR=/" in the merged directory.
 
-Note: this action does **NOT** include everything in the "asl3-asterisk-*" packages.  The focus is on executables (e.g. asterisk) and modules (e.g. app_rpt.so, chan_simpleusb.so, etc).  The assumption we have made is that you are working on software (code) changes and you wish to test them on a system that already has ASL3 installed.
+Note: this action does **NOT** include everything in the "asl3-asterisk-*" packages.  The focus is on executables (e.g. asterisk) and modules (e.g. app\_rpt.so, chan_simpleusb.so, etc).  The assumption we have made is that you are working on software (code) changes and you wish to test them on a system that already has ASL3 installed.
 
 ### Action : **package**
 
@@ -108,24 +108,24 @@ Note: the `build-asl3` script is smart.  If the merged directory does not exist 
 
 The following is an example of how you might use the `build-asl3` command to make a code change.
 
-1. To start, you will want to grab a copy of the asl3-asterisk project (we need the "build-asl3" command).
+1. To start, you will want to grab a copy of the asl3-asterisk project (you need the "build-asl3" command).
 
 	```
 git clone https://github.com/AllStarLink/asl3-asterisk.git
 ```
 
-2.  Optionally, you can [pre-]fetch a copy of the "asterisk" project and checkout the "tag" of the version you wish to use.  If you skip this step (and that's OK) we will download a copy of the "asterisk" source code.
+2.  Optionally, you can [pre-]fetch a copy of the "asterisk" project and checkout the "tag" of the version you wish to use.  If you skip this step (and that's OK) we will download a copy of the "asterisk" project.
 
 	```
 git clone https://github.com/asterisk/asterisk.git
 (cd asterisk; git checkout 20.9.2)
 ```
 
-3. Optionally, you can [pre-]fetch a copy of the "app\_rpt" project.  As above, if you wish to work with a specific version of "app\_rpt" then checkout it's "tag".   If you skip this step (and that's OK) we will download a copy of the "app\_rpt" source code.
+3. Optionally, you can [pre-]fetch a copy of the "app\_rpt" project.  As above, to work with a specific version of "app\_rpt" then checkout it's "tag".  If you skip this step (and that's OK) we will download a copy of the "app\_rpt" project.
 
 	```
 git clone https://github.com/AllStarLink/app_rpt.git
-(cd app_rpt; git checkout 3.0.4)     <-- optional
+(cd app_rpt; git checkout 3.0.4)     <-- optional, i
 ```
 
 4. Create (or update) the merged source directory.
@@ -151,7 +151,13 @@ git clone https://github.com/AllStarLink/app_rpt.git
 
 7. Making iterative changes
 
-	If you need to make changes to your source code, make the updates in the "asterisk", "app\_rpt", and "asl3-asterisk" directories.  Then, repeat step 4 (update the source), step 5 (build), and step 6 (install/test).
+	One must remember that we are building ASL3 Asterisk + app\_rpt using source code that is merged from multiple locations.
+Where changes need to be located can be a challenge.
+Ideally, one would make a change in the "asterisk", "app\_rpt", and "asl3-asterisk" source directories but that's not the merged directory that is used for building.
+
+	After making source code changes you need to re-exec `build-asl3` with the "source" action to update the merged directory and then use the "build" action to recompile what's changed.
+	
+	Once you have updated your source code and recompiled you can than proceed to installing / testing your changes.
 
 ### Experimental Development
 

--- a/build-asl3.1.md
+++ b/build-asl3.1.md
@@ -4,20 +4,17 @@
 
 # NAME
 
-build-asl3 - Build ASL3 Asterisk + app_rpt
+build-asl3 - Build ASL3 Asterisk + app\_rpt
 
 # SYNOPSIS
 
-Usage: `build-asl3 -a ASTV -v RPTV [-r RELV] [-d DESTDIR] [-l] ACTIONS`
+Usage: `build-asl3 [-a ASTV] [-v RPTV] [-r RELV] [-d DESTDIR] [-l] ACTIONS`
 
-Required options :
+Options :
 
-* -a  Asterisk version    (e.g. 20.9.2)
-* -v  ASL/app_rpt version (e.g. 3.0.4)
-
-Optional options :
-
-* -r  Release version (default: 1)
+* -a Asterisk version (default: installed (or latest) version, e.g. "20.9.2")
+* -v ASL/app\_rpt version (default: installed (or latest) version, e.g. "3.0.4")
+* -r  Release version (default: installed (or latest) version, e.g. "1")
 * -d  local install directory (default: "/")
 * -l  Create merged source directory with symlinks
 
@@ -29,13 +26,16 @@ Actions (specify one or more) :
 * install - "install" the build results, locally
 * package - create Debian packages
 
-Note: specifying the **build**, **install**, or **package** actions will, if needed, create the merged source directory.
+Note: specifying the "build", "install", or "package" actions will, if needed,
+create the merged source directory.
 
-Note: you can use the **AST\_VER**, **RPT\_VER**, and **REL\_VER** environment variables to specify the Asterisk, ASL/app_rpt, and Release versions.
+Note: the Asterisk, ASL/app\_rpt, and Release versions will default to those
+of the "asl3-asterisk" package.  You can also use the "AST_VER", "RPT_VER",
+and "REL_VER" environment variables to specify the versions.
 
 # DESCRIPTION
 
-ASL3 Asterisk + app_rpt includes multiple source code projects including [Asterisk](https://github.com/asterisk/asterisk.git), [app_rpt](https://github.com/AllStarLink/app_rpt.git), and [asl3-asterisk](https://github.com/AllStarLink/asl3-asterisk.git).
+ASL3 Asterisk + app\_rpt includes multiple source code projects including [Asterisk](https://github.com/asterisk/asterisk.git), [app\_rpt](https://github.com/AllStarLink/app_rpt.git), and [asl3-asterisk](https://github.com/AllStarLink/asl3-asterisk.git).
 
 The command supports 2 different (but related) workflows :
 
@@ -50,7 +50,7 @@ When using the `build-asl3` command your system works with the following directo
 <base directory>
   asl3-asterisk-AST_VER+asl3-ASL_VER
   asterisk
-  app_rpt
+  app\_rpt
   asl3-asterisk
 ```
 
@@ -60,7 +60,7 @@ Any Debian packages created by `build-asl3` will also be stored in the "\<base d
 
 ## WORKFLOW ACTIONS
 
-Each workflow uses a subset of "actions".
+Each workflow uses one or more of the following "actions".
 
 ### Action : **source**
 
@@ -109,66 +109,70 @@ Note: the `build-asl3` script is smart.  If the merged directory does not exist 
 The following is an example of how you might use the `build-asl3` command to make a code change.
 
 1. To start, you will want to grab a copy of the asl3-asterisk project (you need the "build-asl3" command).
+   
+   ```
+   git clone https://github.com/AllStarLink/asl3-asterisk.git
+   ```
 
-	```
-git clone https://github.com/AllStarLink/asl3-asterisk.git
-```
-
-2.  Optionally, you can [pre-]fetch a copy of the "asterisk" project and checkout the "tag" of the version you wish to use.  If you skip this step (and that's OK) we will download a copy of the "asterisk" project.
-
-	```
-git clone https://github.com/asterisk/asterisk.git
-(cd asterisk; git checkout 20.9.2)
-```
+2. Optionally, you can [pre-]fetch a copy of the "asterisk" project and checkout the "tag" of the version you wish to use.  If you skip this step (and that's OK) we will download a copy of the "asterisk" project.
+   
+   ```
+   git clone https://github.com/asterisk/asterisk.git
+   (cd asterisk; git checkout 20.9.2)
+   ```
 
 3. Optionally, you can [pre-]fetch a copy of the "app\_rpt" project.  As above, to work with a specific version of "app\_rpt" then checkout it's "tag".  If you skip this step (and that's OK) we will download a copy of the "app\_rpt" project.
-
-	```
-git clone https://github.com/AllStarLink/app_rpt.git
-(cd app_rpt; git checkout 3.0.4)     <-- optional, i
-```
+   
+   ```
+   git clone https://github.com/AllStarLink/app_rpt.git
+   (cd app_rpt; git checkout 3.0.4)     <-- optional, i
+   ```
 
 4. Create (or update) the merged source directory.
-
-	```
-	cd asl3-asterisk
-	./build-asl3 -a 20.9.2 -v 3.0.4 -r 1 source
-	```
+   
+   ```
+   cd asl3-asterisk
+   ./build-asl3 source
+   ```
 
 5. Build the sources in the merged source directory.
-
-	```
-	cd asl3-asterisk
-	./build-asl3 -a 20.9.2 -v 3.0.4 -r 1 build
-	```
+   
+   ```
+   cd asl3-asterisk
+   ./build-asl3 build
+   ```
 
 6. Install (and test) your changes.
-
-	```
-	cd asl3-asterisk
-	./build-asl3 -a 20.9.2 -v 3.0.4 -r 1 install
-	```
+   
+   ```
+   cd asl3-asterisk
+   ./build-asl3 install
+   ```
 
 7. Making iterative changes
-
-	One must remember that we are building ASL3 Asterisk + app\_rpt using source code that is merged from multiple locations.
-Where changes need to be located can be a challenge.
-Ideally, one would make a change in the "asterisk", "app\_rpt", and "asl3-asterisk" source directories but that's not the merged directory that is used for building.
-
-	After making source code changes you need to re-exec `build-asl3` with the "source" action to update the merged directory and then use the "build" action to recompile what's changed.
-	
-	Once you have updated your source code and recompiled you can than proceed to installing / testing your changes.
+   
+   One must remember that we are building ASL3 Asterisk + app\_rpt using source code that is merged from multiple locations.  Where changes need to be located can be a challenge.  Ideally, one would make a change in the "asterisk", "app\_rpt", and "asl3-asterisk" source directories but that's not the merged directory that is used for building.
+   
+   After making source code changes you need to re-exec `build-asl3` with the "source" action to update the merged directory and then use the "build" action to recompile what's changed.
+   
+   Once you have updated your source code and recompiled you can than proceed to installing / testing your changes.
 
 ### Experimental Development
 
-The `build-asl3` command usage includes a "-l" option that, for now, should be considered "experimental" due to it's limited testing.
-This option changes how the "asterisk", "app\_rpt", and "asl3-asterisk" directories are merged together.
-Rather than copying each file to the merged directory the command will, instead, symlink the files back to the source directories.
-What this means is that you can make changes in the source directories and not need to re-exec `build-asl3` with the "source" action.
+The `build-asl3` command usage includes a "-l" option that, for now, should be considered "experimental" due to it's limited testing.  This option changes how the "asterisk", "app\_rpt", and "asl3-asterisk" directories are merged together.  Rather than copying each file to the merged directory the command will, instead, symlink the files back to the source directories.  What this means is that you can make changes in the source directories and not need to re-exec `build-asl3` with the "source" action.
 
 Note: some of the files in the merged directory are patched.  If you are making source code changes to any of these [patched] files then you should not use the "-l" option.
 
 Note: the "-l" option can NOT be used when creating Debian packages.
+
+# ENVIRONMENT
+
+| Env Var | Description                                      |
+| ------- | ------------------------------------------------ |
+| AST_VER | "Asterisk" version (to include in merged source) |
+| RPT_VER | "app\_rpt" version (to include in merged source) |
+| REL_VER | Release version (for Debian packaging)           |
+| EMAIL   | E-mail address (for Debian packaging)            |
 
 # BUGS
 


### PR DESCRIPTION
Usage : build-asl3 -a ASTV -v RPTV [-r RELV] [-d DESTDIR] [-l] ACTIONS

Required options :
  -a  Asterisk version    (e.g. 20.9.2)
  -v  ASL/app_rpt version (e.g. 3.0.4)

Optional options :
  -r  Release version         (default: 1)
  -d  local install directory (default: "/")
  -l  Create merged source directory with symlinks

Actions (specify one or more) :
  source  - create the merged source directory
  clean   - "clean" the merged source directory
  build   - "build" the source code
  install - "install" the build results, locally
  package - create Debian packages

Note: specifying "build", "install", or "package" will, if needed, create the merged source directory.

Note: you can use the "AST_VER", "RPT_VER", and "REL_VER" environment variables
to specify the Asterisk, ASL/app_rpt, and Release versions.