### PR TITLE
Add patches for Asterisk changes

### DIFF
--- a/debian/patches/config_c_fix_tryinclude.patch
+++ b/debian/patches/config_c_fix_tryinclude.patch
@@ -1,0 +1,502 @@
+diff --git a/include/asterisk/config.h b/include/asterisk/config.h
+index 44ba4e48778..954508b7183 100644
+--- a/include/asterisk/config.h
++++ b/include/asterisk/config.h
+@@ -914,7 +914,7 @@ void ast_category_rename(struct ast_category *cat, const char *name);
+ struct ast_variable *_ast_variable_new(const char *name, const char *value, const char *filename, const char *file, const char *function, int lineno);
+ #define ast_variable_new(name, value, filename) _ast_variable_new(name, value, filename, __FILE__, __PRETTY_FUNCTION__, __LINE__)
+ 
+-struct ast_config_include *ast_include_new(struct ast_config *conf, const char *from_file, const char *included_file, int is_exec, const char *exec_file, int from_lineno, char *real_included_file_name, int real_included_file_name_size);
++struct ast_config_include *ast_include_new(struct ast_config *conf, const char *from_file, const char *included_file, int include_type, const char *exec_file, int from_lineno, char *real_included_file_name, int real_included_file_name_size);
+ struct ast_config_include *ast_include_find(struct ast_config *conf, const char *included_file);
+ void ast_include_rename(struct ast_config *conf, const char *from_file, const char *to_file);
+ void ast_variable_append(struct ast_category *category, struct ast_variable *variable);
+diff --git a/main/config.c b/main/config.c
+index e7ac4149a6d..7a9fcb60ee0 100644
+--- a/main/config.c
++++ b/main/config.c
+@@ -255,7 +255,28 @@ struct ast_config {
+ 	struct ast_category *last_browse;     /*!< used to cache the last category supplied via category_browse */
+ 	int include_level;
+ 	int max_include_level;
+-	struct ast_config_include *includes;  /*!< a list of inclusions, which should describe the entire tree */
++	/*! First inclusion in the list. */
++	struct ast_config_include *includes_root;
++	/*! Last inclusion in the list. */
++	struct ast_config_include *includes_last;
++};
++
++struct config_included_file {
++	AST_LIST_ENTRY(config_included_file) next;
++	/*|< #include path or matching #tryinclude paths */
++	char path[];
++};
++
++/*!
++ * \brief Types used for ast_include_new() include_type
++ */
++enum include_statement_type {
++	/*! #include statements */
++	CONFIG_STATEMENT_INCLUDE    = 0,
++	/*! #exec statements */
++	CONFIG_STATEMENT_EXEC       = 1,
++	/*! #tryinclude statements */
++	CONFIG_STATEMENT_TRYINCLUDE = 2,
+ };
+ 
+ struct ast_config_include {
+@@ -265,7 +286,7 @@ struct ast_config_include {
+ 	 */
+ 	char *include_location_file;
+ 	int  include_location_lineno;    /*!< lineno where include occurred */
+-	int  exec;                       /*!< set to non-zero if its a #exec statement */
++	enum include_statement_type include_type; /* #include, #exec, #tryinclude */
+ 	/*!
+ 	 * \brief if it's an exec, you'll have both the /var/tmp to read, and the original script
+ 	 * \note Will never be NULL if exec is non-zero
+@@ -276,9 +297,12 @@ struct ast_config_include {
+ 	 * \note Will never be NULL
+ 	 */
+ 	char *included_file;
++	AST_LIST_HEAD_NOLOCK(included_files_list, config_included_file) included_files;	/*|< list of #include/#tryinclude files */
+ 	int inclusion_count;             /*!< if the file is included more than once, a running count thereof -- but, worry not,
+ 	                                      we explode the instances and will include those-- so all entries will be unique */
+ 	int output;                      /*!< a flag to indicate if the inclusion has been output */
++	struct ast_comment *precomments;
++	struct ast_comment *sameline;
+ 	struct ast_config_include *next; /*!< ptr to next inclusion in the list */
+ };
+ 
+@@ -332,14 +356,18 @@ static void ast_variable_move(struct ast_variable *dst_var, struct ast_variable
+ 	src_var->trailing = NULL;
+ }
+ 
+-struct ast_config_include *ast_include_new(struct ast_config *conf, const char *from_file, const char *included_file, int is_exec, const char *exec_file, int from_lineno, char *real_included_file_name, int real_included_file_name_size)
++static void make_fn(char *fn, size_t fn_size, const char *file, const char *configfile);
++
++struct ast_config_include *ast_include_new(struct ast_config *conf, const char *from_file, const char *included_file, int include_type, const char *exec_file, int from_lineno, char *real_included_file_name, int real_included_file_name_size)
+ {
+ 	/* a file should be included ONCE. Otherwise, if one of the instances is changed,
+ 	 * then all be changed. -- how do we know to include it? -- Handling modified
+ 	 * instances is possible, I'd have
+ 	 * to create a new master for each instance. */
+ 	struct ast_config_include *inc;
++	struct config_included_file *inc_file;
+ 	struct stat statbuf;
++	char fn[PATH_MAX];
+ 
+ 	inc = ast_include_find(conf, included_file);
+ 	if (inc) {
+@@ -362,20 +390,65 @@ struct ast_config_include *ast_include_new(struct ast_config *conf, const char *
+ 	else
+ 		inc->included_file = ast_strdup(included_file);
+ 
+-	inc->exec = is_exec;
+-	if (is_exec)
+-		inc->exec_file = ast_strdup(exec_file);
+-
+ 	if (!inc->include_location_file
+ 		|| !inc->included_file
+-		|| (is_exec && !inc->exec_file)) {
++		|| ((include_type == CONFIG_STATEMENT_EXEC) && !inc->exec_file)) {
+ 		ast_includes_destroy(inc);
+ 		return NULL;
+ 	}
+ 
++	inc->include_type = include_type;
++
++	make_fn(fn, sizeof(fn), inc->included_file, from_file);
++	switch (inc->include_type) {
++	case CONFIG_STATEMENT_INCLUDE:
++		inc_file = ast_calloc(1, sizeof(*inc_file) + strlen(fn) + 1);
++		if (inc_file) {
++			strcpy(inc_file->path, fn);	/* safe */
++			AST_LIST_INSERT_TAIL(&inc->included_files, inc_file, next);
++		}
++		break;
++	case CONFIG_STATEMENT_TRYINCLUDE:
++	    {
++		int glob_ret;
++		glob_t globbuf;
++
++		/* add files that match the pattern */
++		globbuf.gl_offs = 0;
++		glob_ret = glob(fn, MY_GLOB_FLAGS, NULL, &globbuf);
++		if (glob_ret == 0) {
++			int i;
++
++			for (i = 0; i < globbuf.gl_pathc; i++) {
++				char *matched_path = globbuf.gl_pathv[i];
++
++				if (access(matched_path, F_OK) != 0) {
++					/* skip #tryinclude paths that do not already exist. */
++					continue;
++				}
++
++				inc_file = ast_calloc(1, sizeof(*inc_file) + strlen(matched_path) + 1);
++				if (inc_file) {
++					strcpy(inc_file->path, matched_path);	/* safe */
++					AST_LIST_INSERT_TAIL(&inc->included_files, inc_file, next);
++				}
++			}
++		}
++		globfree(&globbuf);
++		break;
++	    }
++	case CONFIG_STATEMENT_EXEC:
++		inc->exec_file = ast_strdup(exec_file);
++		break;
++	}
++
+ 	/* attach this new struct to the conf struct */
+-	inc->next = conf->includes;
+-	conf->includes = inc;
++	if (conf->includes_root && conf->includes_last) {
++		conf->includes_last->next = inc;
++	} else {
++		conf->includes_root = inc;
++	}
++	conf->includes_last = inc;
+ 
+ 	return inc;
+ }
+@@ -401,7 +474,7 @@ void ast_include_rename(struct ast_config *conf, const char *from_file, const ch
+ 	/* file names are on categories, includes (of course), and on variables. So,
+ 	 * traverse all this and swap names */
+ 
+-	for (incl = conf->includes; incl; incl=incl->next) {
++	for (incl = conf->includes_root; incl; incl=incl->next) {
+ 		if (strcmp(incl->include_location_file,from_file) == 0) {
+ 			if (from_len >= to_len)
+ 				strcpy(incl->include_location_file, to_file);
+@@ -475,7 +548,7 @@ void ast_include_rename(struct ast_config *conf, const char *from_file, const ch
+ struct ast_config_include *ast_include_find(struct ast_config *conf, const char *included_file)
+ {
+ 	struct ast_config_include *x;
+-	for (x=conf->includes;x;x=x->next) {
++	for (x = conf->includes_root; x; x = x->next) {
+ 		if (strcmp(x->included_file,included_file) == 0)
+ 			return x;
+ 	}
+@@ -1221,16 +1294,33 @@ void ast_category_destroy(struct ast_category *cat)
+ 	ast_free(cat);
+ }
+ 
++static void config_included_files_destroy(struct ast_config_include *incl)
++{
++	struct config_included_file *x;
++
++	while ((x = AST_LIST_REMOVE_HEAD(&incl->included_files, next))) {
++		ast_free(x);
++	}
++}
++
++static void ast_include_destroy(struct ast_config_include *incl)
++{
++	ast_free(incl->include_location_file);
++	ast_free(incl->exec_file);
++	ast_free(incl->included_file);
++	config_included_files_destroy(incl);
++	ast_comment_destroy(&incl->precomments);
++	ast_comment_destroy(&incl->sameline);
++	ast_free(incl);
++}
++
+ static void ast_includes_destroy(struct ast_config_include *incls)
+ {
+ 	struct ast_config_include *incl,*inclnext;
+ 
+ 	for (incl=incls; incl; incl = inclnext) {
+ 		inclnext = incl->next;
+-		ast_free(incl->include_location_file);
+-		ast_free(incl->exec_file);
+-		ast_free(incl->included_file);
+-		ast_free(incl);
++		ast_include_destroy(incl);
+ 	}
+ }
+ 
+@@ -1616,7 +1706,7 @@ void ast_config_destroy(struct ast_config *cfg)
+ 	if (!cfg)
+ 		return;
+ 
+-	ast_includes_destroy(cfg->includes);
++	ast_includes_destroy(cfg->includes_root);
+ 
+ 	cat = cfg->root;
+ 	while (cat) {
+@@ -1908,7 +1998,7 @@ static int handle_include_exec(const char *command, const char *output_file)
+ /*! \brief parse one line in the configuration.
+  * \verbatim
+  * We can have a category header	[foo](...)
+- * a directive				#include / #exec
++ * a directive				#include, #tryinclude, #exec
+  * or a regular line			name = value
+  * \endverbatim
+  */
+@@ -2029,11 +2119,12 @@ static int process_text_line(struct ast_config *cfg, struct ast_category **cat,
+ 		if (newcat) {
+ 			ast_category_append(cfg, newcat);
+ 		}
+-	} else if (cur[0] == '#') { /* A directive - #include or #exec */
++	} else if (cur[0] == '#') { /* A directive - #include, #tryinclude, or #exec */
+ 		char *cur2;
+ 		char real_inclusion_name[256];
+-		int do_include = 0;	/* otherwise, it is exec */
+-		int try_include = 0;
++		int include_type;
++		struct ast_config_include *newinclude;
++		struct ast_config *result;
+ 
+ 		cur++;
+ 		c = cur;
+@@ -2052,15 +2143,15 @@ static int process_text_line(struct ast_config *cfg, struct ast_category **cat,
+ 			c = NULL;
+ 		}
+ 		if (!strcasecmp(cur, "include")) {
+-			do_include = 1;
++			include_type = CONFIG_STATEMENT_INCLUDE;
+ 		} else if (!strcasecmp(cur, "tryinclude")) {
+-			do_include = 1;
+-			try_include = 1;
++			include_type = CONFIG_STATEMENT_TRYINCLUDE;
+ 		} else if (!strcasecmp(cur, "exec")) {
+ 			if (!ast_opt_exec_includes) {
+ 				ast_log(LOG_WARNING, "Cannot perform #exec unless execincludes option is enabled in asterisk.conf (options section)!\n");
+ 				return 0;	/* XXX is this correct ? or we should return -1 ? */
+ 			}
++			include_type = CONFIG_STATEMENT_EXEC;
+ 		} else {
+ 			ast_log(LOG_WARNING, "Unknown directive '#%s' at line %d of %s\n", cur, lineno, configfile);
+ 			return 0;	/* XXX is this correct ? or we should return -1 ? */
+@@ -2068,8 +2159,8 @@ static int process_text_line(struct ast_config *cfg, struct ast_category **cat,
+ 
+ 		if (c == NULL) {
+ 			ast_log(LOG_WARNING, "Directive '#%s' needs an argument (%s) at line %d of %s\n",
+-					do_include ? "include / tryinclude" : "exec",
+-					do_include ? "filename" : "/path/to/executable",
++					cur,
++					(include_type != CONFIG_STATEMENT_EXEC) ? "filename" : "/path/to/executable",
+ 					lineno,
+ 					configfile);
+ 			return 0;	/* XXX is this correct ? or we should return -1 ? */
+@@ -2091,9 +2182,9 @@ static int process_text_line(struct ast_config *cfg, struct ast_category **cat,
+ 		}
+ 		cur2 = cur;
+ 
+-		/* #exec </path/to/executable>
+-		   We create a tmp file, then we #include it, then we delete it. */
+-		if (!do_include) {
++		if (include_type == CONFIG_STATEMENT_EXEC) {
++			/* #exec </path/to/executable>
++			   We create a tmp file, then we #include it, then we delete it. */
+ 			struct timeval now = ast_tvnow();
+ 
+ 			if (!ast_test_flag(&flags, CONFIG_FLAG_NOCACHE))
+@@ -2110,15 +2201,27 @@ static int process_text_line(struct ast_config *cfg, struct ast_category **cat,
+ 		}
+ 		/* A #include */
+ 		/* record this inclusion */
+-		ast_include_new(cfg, cfg->include_level == 1 ? "" : configfile, cur, !do_include, cur2, lineno, real_inclusion_name, sizeof(real_inclusion_name));
++		newinclude = ast_include_new(cfg, cfg->include_level == 1 ? "" : configfile, cur, include_type, cur2, lineno, real_inclusion_name, sizeof(real_inclusion_name));
++		if (!newinclude) {
++			return -1;
++		}
+ 
+-		do_include = ast_config_internal_load(cur, cfg, flags, real_inclusion_name, who_asked) ? 1 : 0;
++		result = ast_config_internal_load(cur, cfg, flags, real_inclusion_name, who_asked);
+ 		if (!ast_strlen_zero(exec_file))
+ 			unlink(exec_file);
+-		if (!do_include && !try_include) {
++		if (!result && (include_type != CONFIG_STATEMENT_TRYINCLUDE)) {
+ 			ast_log(LOG_ERROR, "The file '%s' was listed as a #include but it does not exist.\n", cur);
++			ast_include_destroy(newinclude);
+ 			return -1;
+ 		}
++
++		/* add comments */
++		if (ast_test_flag(&flags, CONFIG_FLAG_WITHCOMMENTS)) {
++			newinclude->precomments = ALLOC_COMMENT(comment_buffer);
++			newinclude->sameline = ALLOC_COMMENT(lline_buffer);
++			CB_RESET(comment_buffer, lline_buffer);
++		}
++
+ 		/* XXX otherwise what ? the default return is 0 anyways */
+ 
+ 	} else {
+@@ -2722,6 +2825,21 @@ static int is_writable(const char *fn)
+ 	return 1;
+ }
+ 
++static void print_include(FILE *f, struct ast_config_include *incl)
++{
++	switch (incl->include_type) {
++	case CONFIG_STATEMENT_INCLUDE:
++		fprintf(f,"#include \"%s\"\n", incl->included_file);
++		break;
++	case CONFIG_STATEMENT_TRYINCLUDE:
++		fprintf(f,"#tryinclude \"%s\"\n", incl->included_file);
++		break;
++	case CONFIG_STATEMENT_EXEC:
++		fprintf(f,"#exec \"%s\"\n", incl->exec_file);
++		break;
++	}
++}
++
+ int ast_config_text_file_save2(const char *configfile, const struct ast_config *cfg, const char *generator, uint32_t flags)
+ {
+ 	FILE *f;
+@@ -2742,15 +2860,31 @@ int ast_config_text_file_save2(const char *configfile, const struct ast_config *
+ 	}
+ 
+ 	/* Check all the files for write access before attempting to modify any of them */
+-	for (incl = cfg->includes; incl; incl = incl->next) {
++	for (incl = cfg->includes_root; incl; incl = incl->next) {
+ 		/* reset all the output flags in case this isn't our first time saving this data */
+ 		incl->output = 0;
+ 
+-		if (!incl->exec) {
+-			/* now make sure we have write access to the include file or its parent directory */
+-			make_fn(fn, sizeof(fn), incl->included_file, configfile);
+-			/* If the file itself doesn't exist, make sure we have write access to the directory */
+-			if (!is_writable(fn)) {
++		if (incl->include_type != CONFIG_STATEMENT_EXEC) {
++			struct config_included_file *included_file;
++			int ok = 0;
++
++			/* Not a #exec. */
++			/* For #include, make sure we have write access to the include file
++			   file or its parent directory.  If the file itself doesn't exist,
++			   make sure we have write access to the directory. */
++			/* For #tryinclude, we check the file(s) that match the pattern. */
++
++			AST_LIST_TRAVERSE(&incl->included_files, included_file, next) {
++				if (!is_writable(included_file->path)) {
++					/* the #tryinclude path exists but is not writable */
++					ok = -1;
++					break;
++				}
++			}
++
++			if (ok != 0) {
++				/* at least one include file is not writable */
++				ao2_ref(fileset, -1);
+ 				return -1;
+ 			}
+ 		}
+@@ -2759,6 +2893,7 @@ int ast_config_text_file_save2(const char *configfile, const struct ast_config *
+ 	/* now make sure we have write access to the main config file or its parent directory */
+ 	make_fn(fn, sizeof(fn), 0, configfile);
+ 	if (!is_writable(fn)) {
++		ao2_ref(fileset, -1);
+ 		return -1;
+ 	}
+ 
+@@ -2766,19 +2901,24 @@ int ast_config_text_file_save2(const char *configfile, const struct ast_config *
+ 
+ 	/* go thru all the inclusions and make sure all the files involved (configfile plus all its inclusions)
+ 	   are all truncated to zero bytes and have that nice header*/
+-	for (incl = cfg->includes; incl; incl = incl->next) {
+-		if (!incl->exec) { /* leave the execs alone -- we'll write out the #exec directives, but won't zero out the include files or exec files*/
+-			/* normally, fn is just set to incl->included_file, prepended with config dir if relative */
+-			fi = set_fn(fn, sizeof(fn), incl->included_file, configfile, fileset);
+-			f = fopen(fn, "w");
+-			if (f) {
+-				gen_header(f, configfile, fn, generator);
+-				fclose(f); /* this should zero out the file */
+-			} else {
+-				ast_log(LOG_ERROR, "Unable to write %s (%s)\n", fn, strerror(errno));
+-			}
+-			if (fi) {
+-				ao2_ref(fi, -1);
++	/* Note: for #exec, we write out the directives but don't zero out the exec files */
++	for (incl = cfg->includes_root; incl; incl = incl->next) {
++		if (incl->include_type != CONFIG_STATEMENT_EXEC) {
++			struct config_included_file *included_file;
++
++			AST_LIST_TRAVERSE(&incl->included_files, included_file, next) {
++				fi = set_fn(fn, sizeof(fn), included_file->path, configfile, fileset);
++				f = fopen(fn, "w");
++				if (f) {
++					ast_verb(2, "Saving tryinclude '%s'\n", fn);
++					gen_header(f, configfile, fn, generator);
++					fclose(f);
++				} else {
++					ast_log(LOG_ERROR, "Unable to write %s (%s)\n", fn, strerror(errno));
++				}
++				if (fi) {
++					ao2_ref(fi, -1);
++				}
+ 			}
+ 		}
+ 	}
+@@ -2817,13 +2957,16 @@ int ast_config_text_file_save2(const char *configfile, const struct ast_config *
+ 			}
+ 
+ 			/* dump any includes that happen before this category header */
+-			for (incl=cfg->includes; incl; incl = incl->next) {
++			for (incl=cfg->includes_root; incl; incl = incl->next) {
+ 				if (strcmp(incl->include_location_file, cat->file) == 0){
+ 					if (cat->lineno > incl->include_location_lineno && !incl->output) {
+-						if (incl->exec)
+-							fprintf(f,"#exec \"%s\"\n", incl->exec_file);
+-						else
+-							fprintf(f,"#include \"%s\"\n", incl->included_file);
++						insert_leading_blank_lines(f, fi, incl->precomments, incl->include_location_lineno);
++						for (cmt = incl->precomments; cmt; cmt=cmt->next) {
++							if (cmt->cmt[0] != ';' || cmt->cmt[1] != '!')
++								fprintf(f,"%s", cmt->cmt);
++						}
++
++						print_include(f, incl);
+ 						incl->output = 1;
+ 					}
+ 				}
+@@ -2922,14 +3065,17 @@ int ast_config_text_file_save2(const char *configfile, const struct ast_config *
+ 					return -1;
+ 				}
+ 
+-				/* dump any includes that happen before this category header */
+-				for (incl=cfg->includes; incl; incl = incl->next) {
++				/* dump any includes that happen before this variable header */
++				for (incl=cfg->includes_root; incl; incl = incl->next) {
+ 					if (strcmp(incl->include_location_file, var->file) == 0){
+ 						if (var->lineno > incl->include_location_lineno && !incl->output) {
+-							if (incl->exec)
+-								fprintf(f,"#exec \"%s\"\n", incl->exec_file);
+-							else
+-								fprintf(f,"#include \"%s\"\n", incl->included_file);
++							insert_leading_blank_lines(f, fi, incl->precomments, incl->include_location_lineno);
++							for (cmt = incl->precomments; cmt; cmt=cmt->next) {
++								if (cmt->cmt[0] != ';' || cmt->cmt[1] != '!')
++									fprintf(f,"%s", cmt->cmt);
++							}
++
++							print_include(f, incl);
+ 							incl->output = 1;
+ 						}
+ 					}
+@@ -2988,7 +3134,7 @@ int ast_config_text_file_save2(const char *configfile, const struct ast_config *
+ 
+ 	/* Now, for files with trailing #include/#exec statements,
+ 	   we have to make sure every entry is output */
+-	for (incl=cfg->includes; incl; incl = incl->next) {
++	for (incl=cfg->includes_root; incl; incl = incl->next) {
+ 		if (!incl->output) {
+ 			/* open the respective file */
+ 			fi = set_fn(fn, sizeof(fn), incl->include_location_file, configfile, fileset);
+@@ -3004,12 +3150,9 @@ int ast_config_text_file_save2(const char *configfile, const struct ast_config *
+ 			}
+ 
+ 			/* output the respective include */
+-			if (incl->exec)
+-				fprintf(f,"#exec \"%s\"\n", incl->exec_file);
+-			else
+-				fprintf(f,"#include \"%s\"\n", incl->included_file);
+-			fclose(f);
++			print_include(f, incl);
+ 			incl->output = 1;
++			fclose(f);
+ 			if (fi) {
+ 				ao2_ref(fi, -1);
+ 			}

--- a/debian/patches/config_c_fix_whitespace.patch
+++ b/debian/patches/config_c_fix_whitespace.patch
@@ -1,0 +1,23 @@
+diff --git a/main/config.c b/main/config.c
+index e3438da6c9b..3793f29c250 100644
+--- a/main/config.c
++++ b/main/config.c
+@@ -2469,6 +2469,18 @@ static struct ast_config *config_text_file_load(const char *database, const char
+ 								if (!comment) {
+ 									/* If ; is found, and we are not nested in a comment,
+ 									   we immediately stop all comment processing */
++									while ((comment_p > new_buf) && isspace(*(comment_p - 1))) {
++										/* To preserve comment formatting we want to include any
++										   whitespace before the ";" */
++										comment_p--;
++									}
++									if ((comment_p != new_buf) && (*comment_p == ' ') && (*(comment_p + 1) == ' ')) {
++										/* If the comment (w/whitespace) does not start in column 1
++										   then, when written out, the preceeding variable/value will
++										   be separated from the comment by two spaces. To preserve
++										   comment formatting we should also take this into account. */
++										comment_p += 2;
++									}
+ 									if (ast_test_flag(&flags, CONFIG_FLAG_WITHCOMMENTS)) {
+ 										CB_ADD(&lline_buffer, comment_p);
+ 									}

--- a/debian/patches/dns_round_robin.patch
+++ b/debian/patches/dns_round_robin.patch
@@ -1,0 +1,142 @@
+diff --git a/include/asterisk/acl.h b/include/asterisk/acl.h
+index 14a9c6524f9..fda4dc3138d 100644
+--- a/include/asterisk/acl.h
++++ b/include/asterisk/acl.h
+@@ -287,6 +287,33 @@ int ast_get_ip(struct ast_sockaddr *addr, const char *hostname);
+  */
+ int ast_get_ip_or_srv(struct ast_sockaddr *addr, const char *hostname, const char *service);
+ 
++/*!
++ * \brief Get the IP address given a hostname and optional service with a preferred result
++ *
++ * \details
++ * If the service parameter is non-NULL, then an SRV lookup will be made by
++ * prepending the service to the hostname parameter, separated by a '.'
++ * For example, if hostname is "example.com" and service is "_sip._udp" then
++ * an SRV lookup will be done for "_sip._udp.example.com". If service is NULL,
++ * then this function acts exactly like a call to ast_get_ip.
++ *
++ * \param addr The IP address found.  The address family is used as an input
++ * parameter to filter the returned addresses.  If it is 0, both IPv4 and
++ * IPv6 addresses can be returned.
++ *
++ * \param hostname The hostname to look up
++ * \param service A specific service provided by the host. A NULL service results
++ * in an A-record lookup instead of an SRV lookup
++ * \param preference The preferred IP address to return. If multiple results are
++ * available and this IP address is in the list then it will be returned. If NULL,
++ * or if the none of the returned IP addresses match, then the first IP address
++ * will be returned.
++ * \retval 0 Success
++ * \retval -1 Failure
++ */
++int ast_get_ip_or_srv_with_preference(struct ast_sockaddr *addr, const char *hostname,
++									  const char *service, struct ast_sockaddr *preference);
++
+ /*!
+  * \brief Get our local IP address when contacting a remote host
+  *
+diff --git a/main/acl.c b/main/acl.c
+index fe388da5389..772b0fb0df9 100644
+--- a/main/acl.c
++++ b/main/acl.c
+@@ -872,18 +872,29 @@ enum ast_acl_sense ast_apply_ha(const struct ast_ha *ha, const struct ast_sockad
+ 	return res;
+ }
+ 
+-static int resolve_first(struct ast_sockaddr *addr, const char *name, int flag,
+-			 int family)
++static int resolve_match_or_first(struct ast_sockaddr *addr, const char *name, int flag,
++								  int family, struct ast_sockaddr *preference)
+ {
+ 	struct ast_sockaddr *addrs;
+ 	int addrs_cnt;
+ 
+ 	addrs_cnt = ast_sockaddr_resolve(&addrs, name, flag, family);
+ 	if (addrs_cnt > 0) {
+-		if (addrs_cnt > 1) {
++		struct ast_sockaddr *resolved = &addrs[0];
++
++		if (preference) {
++			int i;
++
++			for (i = 0; i < addrs_cnt; i++) {
++				if (!ast_sockaddr_cmp_addr(preference, &addrs[i])) {
++					resolved = &addrs[i];
++					break;
++				}
++			}
++		} else if (addrs_cnt > 1) {
+ 			ast_debug(1, "Multiple addresses. Using the first only\n");
+ 		}
+-		ast_sockaddr_copy(addr, &addrs[0]);
++		ast_sockaddr_copy(addr, resolved);
+ 		ast_free(addrs);
+ 	} else {
+ 		ast_log(LOG_WARNING, "Unable to lookup '%s'\n", name);
+@@ -893,7 +904,8 @@ static int resolve_first(struct ast_sockaddr *addr, const char *name, int flag,
+ 	return 0;
+ }
+ 
+-int ast_get_ip_or_srv(struct ast_sockaddr *addr, const char *hostname, const char *service)
++int ast_get_ip_or_srv_with_preference(struct ast_sockaddr *addr, const char *hostname,
++									  const char *service, struct ast_sockaddr *preference)
+ {
+ 	char srv[256];
+ 	char host[256];
+@@ -907,7 +919,7 @@ int ast_get_ip_or_srv(struct ast_sockaddr *addr, const char *hostname, const cha
+ 		}
+ 	}
+ 
+-	if (resolve_first(addr, hostname, PARSE_PORT_FORBID, addr->ss.ss_family) != 0) {
++	if (resolve_match_or_first(addr, hostname, PARSE_PORT_FORBID, addr->ss.ss_family, preference) != 0) {
+ 		return -1;
+ 	}
+ 
+@@ -918,6 +930,11 @@ int ast_get_ip_or_srv(struct ast_sockaddr *addr, const char *hostname, const cha
+ 	return 0;
+ }
+ 
++int ast_get_ip_or_srv(struct ast_sockaddr *addr, const char *hostname, const char *service)
++{
++	return ast_get_ip_or_srv_with_preference(addr, hostname, service, NULL);
++}
++
+ struct dscp_codepoint {
+ 	char *name;
+ 	unsigned int space;
+@@ -1064,17 +1081,17 @@ int ast_find_ourip(struct ast_sockaddr *ourip, const struct ast_sockaddr *bindad
+ 	if (gethostname(ourhost, sizeof(ourhost) - 1)) {
+ 		ast_log(LOG_WARNING, "Unable to get hostname\n");
+ 	} else {
+-		if (resolve_first(ourip, ourhost, PARSE_PORT_FORBID, family) == 0) {
+-			/* reset port since resolve_first wipes this out */
++		if (resolve_match_or_first(ourip, ourhost, PARSE_PORT_FORBID, family, NULL) == 0) {
++			/* reset port since resolve_match_or_first wipes this out */
+ 			ast_sockaddr_set_port(ourip, port);
+ 			return 0;
+ 		}
+ 	}
+ 	ast_debug(3, "Trying to check A.ROOT-SERVERS.NET and get our IP address for that connection\n");
+ 	/* A.ROOT-SERVERS.NET. */
+-	if (!resolve_first(&root, "A.ROOT-SERVERS.NET", PARSE_PORT_FORBID, 0) &&
++	if (!resolve_match_or_first(&root, "A.ROOT-SERVERS.NET", PARSE_PORT_FORBID, 0, NULL) &&
+ 	    !ast_ouraddrfor(&root, ourip)) {
+-		/* reset port since resolve_first wipes this out */
++		/* reset port since resolve_match_or_first wipes this out */
+ 		ast_sockaddr_set_port(ourip, port);
+ 		return 0;
+ 	}
+diff --git a/main/dnsmgr.c b/main/dnsmgr.c
+index bcde08251ea..1140d47f437 100644
+--- a/main/dnsmgr.c
++++ b/main/dnsmgr.c
+@@ -211,7 +211,7 @@ static int dnsmgr_refresh(struct ast_dnsmgr_entry *entry, int verbose)
+ 	ast_debug(6, "refreshing '%s'\n", entry->name);
+ 
+ 	tmp.ss.ss_family = entry->family;
+-	if (!ast_get_ip_or_srv(&tmp, entry->name, entry->service)) {
++	if (!ast_get_ip_or_srv_with_preference(&tmp, entry->name, entry->service, entry->result)) {
+ 		if (!ast_sockaddr_port(&tmp)) {
+ 			ast_sockaddr_set_port(&tmp, ast_sockaddr_port(entry->result));
+ 		}

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -9,4 +9,7 @@
 2010_astdatadir.patch
 config_c_fix_template_inheritance_overrides.patch
 config_c_fix_template_writing.patch
+config_c_fix_tryinclude.patch
+config_c_fix_whitespace.patch
+dns_round_robin.patch
 sounds_ulaw_default


### PR DESCRIPTION
1. config_c_fix_tryinclude.patch

   - Asterisk [Issue #920](https://github.com/asterisk/asterisk/issues/920), [PR #918](https://github.com/asterisk/asterisk/pull/918)

   Correct an issue in ast_config_text_file_save2() when updating configuration files with "#tryinclude" statements. The API currently replaces "#tryinclude" with "#include". The API also creates empty template files if the referenced files do not exist.

2. config_c_fix_whitespace.patch

   - Asterisk [Issue #970](https://github.com/asterisk/asterisk/issues/970), [PR #971](https://github.com/asterisk/asterisk/pull/971)

   Configurations loaded with the ast_config_load2() API and later written out with ast_config_text_file_save2() will have any leading whitespace stripped away.  The APIs should make reasonable efforts to maintain the content and formatting of the configuration files.

3. dns_round_robin.patch

   - Asterisk [Issue #924](https://github.com/asterisk/asterisk/issues/924), [PR #925](https://github.com/asterisk/asterisk/pull/925)

   The dnsmgr_refresh() function checks to see if the IP address associated with a name/service has changed. The gotcha is that the ast_get_ip_or_srv() function only returns the first IP address returned by the DNS query. If there are multiple IPs associated with the name and the returned order is not consistent (e.g. with DNS round-robin) then the other IP addresses are not included in the comparison and the entry is flagged as changed even though the IP is still valid.