### PR TITLE
Need "/var/lib/asterisk/sounds/custom" directory

### DIFF
--- a/debian/asl3-asterisk.dirs
+++ b/debian/asl3-asterisk.dirs
@@ -5,7 +5,7 @@ usr/share/asterisk/static-http
 var/lib/asterisk
 var/lib/asterisk/moh
 var/lib/asterisk/priv-callerintros
-var/lib/asterisk/sounds
+var/lib/asterisk/sounds/custom
 var/log/asterisk
 var/log/asterisk/cdr-csv
 var/log/asterisk/cdr-custom


### PR DESCRIPTION
In .../debian/asl3-asterisk.links, we create a symlink from :
  "/usr/share/asterisk/sounds/recordings"
to :
  "/var/lib/asterisk/sounds/custom"

We need to ensure that the latter directory exists.