### PR TITLE
Add patch for "sounds_search_custom_dir" warning messages

### DIFF
--- a/debian/patches/file_c_search_custom_dir_no_warnings
+++ b/debian/patches/file_c_search_custom_dir_no_warnings
@@ -1,0 +1,58 @@
+diff --git a/main/file.c b/main/file.c
+index 0f29ca82db2..039e33b19aa 100644
+--- a/main/file.c
++++ b/main/file.c
+@@ -787,13 +787,8 @@ static int fileexists_core(const char *filename, const char *fmt, const char *pr
+ 	return 0;
+ }
+ 
+-struct ast_filestream *ast_openstream(struct ast_channel *chan, const char *filename, const char *preflang)
+-{
+-	return ast_openstream_full(chan, filename, preflang, 0);
+-}
+-
+-struct ast_filestream *ast_openstream_full(struct ast_channel *chan,
+-	const char *filename, const char *preflang, int asis)
++static struct ast_filestream *openstream_internal(struct ast_channel *chan,
++	const char *filename, const char *preflang, int asis, int quiet)
+ {
+ 	/*
+ 	 * Use fileexists_core() to find a file in a compatible
+@@ -822,7 +817,9 @@ struct ast_filestream *ast_openstream_full(struct ast_channel *chan,
+ 	if (!fileexists_core(filename, NULL, preflang, buf, buflen, file_fmt_cap) ||
+ 		!ast_format_cap_has_type(file_fmt_cap, AST_MEDIA_TYPE_AUDIO)) {
+ 
+-		ast_log(LOG_WARNING, "File %s does not exist in any format\n", filename);
++		if (!quiet) {
++			ast_log(LOG_WARNING, "File %s does not exist in any format\n", filename);
++		}
+ 		ao2_ref(file_fmt_cap, -1);
+ 		return NULL;
+ 	}
+@@ -845,6 +842,17 @@ struct ast_filestream *ast_openstream_full(struct ast_channel *chan,
+ 	return NULL;
+ }
+ 
++struct ast_filestream *ast_openstream(struct ast_channel *chan, const char *filename, const char *preflang)
++{
++	return openstream_internal(chan, filename, preflang, 0, 0);
++}
++
++struct ast_filestream *ast_openstream_full(struct ast_channel *chan,
++	const char *filename, const char *preflang, int asis)
++{
++	return openstream_internal(chan, filename, preflang, asis, 0);
++}
++
+ struct ast_filestream *ast_openvstream(struct ast_channel *chan,
+ 	const char *filename, const char *preflang)
+ {
+@@ -1307,7 +1315,7 @@ int ast_streamfile(struct ast_channel *chan, const char *filename,
+ 	if (ast_opt_sounds_search_custom && !is_absolute_path(filename)) {
+ 		memset(custom_filename, 0, sizeof(custom_filename));
+ 		snprintf(custom_filename, sizeof(custom_filename), "custom/%s", filename);
+-		fs = ast_openstream(chan, custom_filename, preflang);
++		fs = openstream_internal(chan, filename, preflang, 0, 1); /* open stream, do not warn for missing files */
+ 		if (fs) {
+ 			tmp_filename = custom_filename;
+ 			ast_debug(3, "Found file %s in custom directory\n", filename);

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -24,3 +24,4 @@ config_c_fix_missing_include_crash.patch
 sounds_ulaw_default
 enable_custom_sounddir.patch
 #chan_iax2_unknown_format.patch
+file_c_search_custom_dir_no_warnings

--- a/debian/patches/series.v20
+++ b/debian/patches/series.v20
@@ -24,3 +24,4 @@ config_c_fix_missing_include_crash.patch
 sounds_ulaw_default
 enable_custom_sounddir.patch
 #chan_iax2_unknown_format.patch
+file_c_search_custom_dir_no_warnings


### PR DESCRIPTION
Add/apply [Asterisk PR #1172](https://github.com/asterisk/asterisk/pull/1172) patch for the warning messages issued when a sound file does not exist in the "custom" directory.