### PR TITLE
Correct "astmoddir" path

### DIFF
--- a/debian/asl3-asterisk-config.postinst
+++ b/debian/asl3-asterisk-config.postinst
@@ -34,6 +34,10 @@ case "$1" in
 	perl -pi -e 's/^;sounds_search_custom_dir\s+=\s+no/sounds_search_custom_dir = yes/g' \
 		/etc/asterisk/asterisk.conf
 
+	# update the asterisk module directory path
+	perl -pi -e "s;/usr/lib/.*-linux-gnu/asterisk/modules;/usr/lib/`arch`-linux-gnu/asterisk/modules;" \
+		/etc/asterisk/asterisk.conf
+
 	# change insecure default passwords, if present
 	RAND_IAX=$(openssl rand -hex 16)
 	perl -pi -e "s/Your_Secret_Password_Here/${RAND_IAX}/g" \


### PR DESCRIPTION
Our template `asterisk.conf` file includes an "astmoddir" variable that should reference the Asterisk module directory.  On Debian, the path is architecture specific.  So far, despite the path being incorrect on some architectures, we've been OK as `asterisk` knows were to find/load it's own modules.  But, the Asterisk "testsuite" is not as smart and uses this variable to find the module directory.  This change ensures that the path is correct.