### PR TITLE
Remove Unneeded Dependency

### DIFF
--- a/install-build-deps
+++ b/install-build-deps
@@ -15,7 +15,6 @@ apt -y install  autoconf \
  libavcodec-dev \
  libavdevice-dev \
  libbluetooth-dev \
- libc-client2007e-dev \
  libcap-dev \
  libcodec2-dev \
  libcurl4-openssl-dev \


### PR DESCRIPTION
Remove `lib-client2007e-dev` from `install-build-deps`; no longer exists in Debian 13