### PR TITLE
Check/Install DAHDI Modules at Start

### DIFF
--- a/debian/asl3-asterisk.install
+++ b/debian/asl3-asterisk.install
@@ -1,6 +1,7 @@
 etc/logrotate.d/*
 lib/systemd/system/asterisk.service
 usr/bin/asterisk-config-custom
+usr/bin/asl-dahdi-repair
 usr/lib/${DEB_HOST_MULTIARCH}/libasterisk*
 usr/sbin
 usr/share/asterisk/conf

--- a/debian/patches/1006_systemd.patch
+++ b/debian/patches/1006_systemd.patch
@@ -82,7 +82,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 +fi
 --- /dev/null
 +++ b/contrib/asterisk.service
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,56 @@
 +[Unit]
 +Description=Asterisk PBX
 +Documentation=man:asterisk(8)

--- a/debian/patches/1006_systemd.patch
+++ b/debian/patches/1006_systemd.patch
@@ -91,6 +91,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 +
 +[Service]
 +Type=notify
++ExecStartPre=/usr/bin/asl-dahdi-repair
 +ExecStart=__ASTERISK_SBIN_DIR__/asterisk -g -f -p -U asterisk
 +ExecReload=__ASTERISK_SBIN_DIR__/asterisk -rx 'core reload'
 +Restart=on-failure

--- a/debian/rules
+++ b/debian/rules
@@ -382,6 +382,7 @@ execute_after_dh_auto_install:
 	install -D -m 644 etc/90-asl3.rules debian/tmp/etc/udev/rules.d/90-asl3.rules
 	install -D -m 644 debian/asterisk.logrotate debian/tmp/etc/logrotate.d/asterisk
 	install -D -m 755 contrib/scripts/ast_coredumper debian/tmp/var/lib/asterisk/scripts/ast_coredumper
+	install -D -m 755 debian/scripts/asl-dahdi-repair debian/tmp/usr/bin/asl-dahdi-repair
 
 #execute_after_dh_install-arch:
 #	extra_packs=$$(find $(SUBPACKS_EXTRA_DIRS_MOD) -name '*.so' -printf '%f\n');\

--- a/debian/scripts/asl-dahdi-repair
+++ b/debian/scripts/asl-dahdi-repair
@@ -1,0 +1,34 @@
+#!/usr/bin/bash
+
+KVER=$(uname -r)
+DAHDI_INSTALLED=$(lsmod | grep -E '^dahdi' | wc -l)
+
+# If there are 3 DADHI modules - dahdi, dahdi_dummy, dahdi_transcode
+# then DAHDI is installed and working for the current kernel.
+if [ ${DAHDI_INSTALLED} == 3 ]; then
+	exit 0
+fi
+
+# Is the kernel headers installed?
+export DEBIAN_FRONTEND=noninteractive
+KHDRS=$(dpkg -l | awk '{print $2}' | grep linux-headers-${KVER} | wc -l)
+if [ ${KHDRS} == 0 ]; then
+	echo "========== Installing linux-headers-${KVER} =========="
+	apt update > /dev/null 2&>1
+	apt -qy install linux-headers-${KVER}
+	echo "========== Done =========="
+fi
+
+echo "========== Building DAHDI with DKMS ==========="
+DVER=$(dpkg -l | grep dahdi-dkms | awk '{print $3}' | perl -pe 's/^?[0-9]+:?([0-9\.]+)\-.*$/$1/g')
+dkms build -m dahdi -v ${DVER} -k $(uname -r) --force
+dkms install -m dahdi -v ${DVER} -k $(uname -r) --force
+
+for k in dahdi dahdi_transcode dahdi_dummy
+do
+	modprobe $k
+done
+
+echo "========== Done =========="
+
+exit 0

--- a/debian/scripts/asl-dahdi-repair
+++ b/debian/scripts/asl-dahdi-repair
@@ -1,7 +1,7 @@
 #!/usr/bin/bash
 
 KVER=$(uname -r)
-DAHDI_INSTALLED=$(lsmod | grep -E '^dahdi' | wc -l)
+DAHDI_INSTALLED=$(lsmod | grep -E '^(dahdi|dahdi_dummy|dahdi_transcode) ' | wc -l)
 
 # If there are 3 DADHI modules - dahdi, dahdi_dummy, dahdi_transcode
 # then DAHDI is installed and working for the current kernel.


### PR DESCRIPTION
Opening this for consideration/discussion. Given the fact that Trixie seems to be "missing" upgrades for `linux-headers-$(uname -r)`, this pull adds the script `asl-dahdi-repair` and calls that from `ExecStartPre=` to check and - If needed - install DAHDI. The worst-case impact is on a slow Pi where the startup script has to do an `apt update` and `apt install` to get the linux-headers package and then the DKMS build. This would be fairly slow on a Pi Zero 2W and is fairly quick on a VPS host.