### PR TITLE
Add AmbientCapabilities=CAP_NET_BIND_SERVICE

### DIFF
--- a/debian/patches/1006_systemd.patch
+++ b/debian/patches/1006_systemd.patch
@@ -103,6 +103,9 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 +StandardOutput=null
 +StandardError=null
 +
++# Allow asterisk to bind to port below 1025 (e.g. chan_voter)
++AmbientCapabilities=CAP_NET_BIND_SERVICE
++
 +# Extra settings:
 +# If you want to set them, you can add them to a file in the directory
 +# /lib/systemd/system/asterisk.service.d/ with the extension .conf.

--- a/debian/patches/1006_systemd.patch
+++ b/debian/patches/1006_systemd.patch
@@ -82,7 +82,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 +fi
 --- /dev/null
 +++ b/contrib/asterisk.service
-@@ -0,0 +1,55 @@
+@@ -0,0 +1,58 @@
 +[Unit]
 +Description=Asterisk PBX
 +Documentation=man:asterisk(8)
@@ -103,7 +103,7 @@ This patch header follows DEP-3: http://dep.debian.net/deps/dep3/
 +StandardOutput=null
 +StandardError=null
 +
-+# Allow asterisk to bind to port below 1025 (e.g. chan_voter)
++# Allow asterisk to bind to port below 1024 (e.g. chan_voter)
 +AmbientCapabilities=CAP_NET_BIND_SERVICE
 +
 +# Extra settings:


### PR DESCRIPTION
This allows chan_voter to bind to port=667 without running as root.