### PR TITLE
Add udev rule for hidraw CM1xx

### DIFF
--- a/etc/90-asl3.rules
+++ b/etc/90-asl3.rules
@@ -1,3 +1,4 @@
 SUBSYSTEM=="usb", ATTRS{idVendor}=="0d8c", GROUP="plugdev", TAG+="uaccess"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="0d8c", GROUP="plugdev", TAG+="uaccess"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1209", GROUP="plugdev", TAG+="uaccess"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1209", GROUP="plugdev", TAG+="uaccess"


### PR DESCRIPTION
Although not directly required by asl3, this enables easy management of CMxxx modules over HIDRAW for example when an AIOC is put in CM108 emulation mode. This matches the existing hidraw rule, which makes management of AIOCs already easy.