### PR TITLE
Allow .conf files in "/etc/asterisk/custom"

### DIFF
--- a/debian/asl3-asterisk-config.postinst
+++ b/debian/asl3-asterisk-config.postinst
@@ -15,6 +15,11 @@ case "$1" in
     configure)
 	set +e # ignore errors temporarily
 
+	# set /etc/asterisk/custom dir ownership
+	if [ -d /etc/asterisk/custom ]; then
+		chown asterisk: /etc/asterisk/custom
+	fi
+
 	# find conffiles under /etc/asterisk belonging to asterisk-config
 	# and chown them to user asterisk.
 	dpkg-query -W -f='${Conffiles}\n' asl3-asterisk-config 2>/dev/null | \

--- a/debian/rules
+++ b/debian/rules
@@ -374,7 +374,7 @@ execute_after_dh_auto_install:
 	$(RM) -f debian/tmp/usr/sbin/stereorize
 	$(RM) -f debian/tmp/usr/sbin/hashtest*
 	$(RM) -f debian/tmp/usr/sbin/refcounter
-	cp configs/asl3/* debian/tmp/etc/asterisk/
+	cp -r configs/asl3/* debian/tmp/etc/asterisk/
 	$(RM) -f debian/tmp/etc/asterisk/users.conf
 	mkdir -p debian/tmp/usr/share/asterisk/sounds/en/rpt
 	cp rpt-sounds/* debian/tmp/usr/share/asterisk/sounds/en/rpt


### PR DESCRIPTION
Most of the AllStarLink and "app_rpt" configuration files are pulled from the `.../app_rpt/configs/rpt` directory and end up in the `/etc/asterisk` directory.  This change enables "app_rpt" to contribute configuration files to the `/etc/asterisk/custom` directory.

The first "custom" configuration files will likely be contributed by https://github.com/AllStarLink/app_rpt/pull/591