### PR TITLE
Drop snd_pcm_oss autoload for PortAudio-based app_rpt

### DIFF
--- a/debian/asl3-asterisk.install
+++ b/debian/asl3-asterisk.install
@@ -12,7 +12,6 @@ usr/share/asterisk/rest-api
 usr/share/asterisk/moh
 usr/share/asterisk/sounds
 usr/share/dahdi/span_config.d/50-asterisk
-etc/modules-load.d/*.conf
 etc/udev/rules.d/*.rules
 var/lib/asterisk/scripts/*
 var/spool/asterisk/voicemail/*

--- a/debian/asl3-asterisk.install
+++ b/debian/asl3-asterisk.install
@@ -12,6 +12,7 @@ usr/share/asterisk/rest-api
 usr/share/asterisk/moh
 usr/share/asterisk/sounds
 usr/share/dahdi/span_config.d/50-asterisk
+etc/modules-load.d/*.conf
 etc/udev/rules.d/*.rules
 var/lib/asterisk/scripts/*
 var/spool/asterisk/voicemail/*

--- a/debian/asl3-asterisk.postinst
+++ b/debian/asl3-asterisk.postinst
@@ -89,8 +89,10 @@ case "$1" in
 			2>/dev/null
 	done
 
-	# load the modules we care about
-	modprobe -aq snd-pcm-oss
+	# load OSS module when this package ships asl3-oss.conf (OSS-based app_rpt)
+	if [ -f /etc/modules-load.d/asl3-oss.conf ]; then
+		modprobe -aq snd-pcm-oss
+	fi
 
 	# remove customized /etc/systemd/system/asterisk.service
 	test -f /etc/systemd/system/asterisk.service && \

--- a/debian/rules
+++ b/debian/rules
@@ -389,7 +389,8 @@ execute_after_dh_auto_install:
 		mv -f debian/tmp/usr/share/asterisk/sounds/en/rpt/transceive.ulaw \
 		      debian/tmp/usr/share/asterisk/sounds/en/rpt/tranceive.ulaw; \
 	fi
-	install -D -m 644 etc/asl3-oss.conf  debian/tmp/etc/modules-load.d/asl3-oss.conf
+	# OSS (/dev/dsp) removed: app_rpt uses PortAudio (ALSA) as of portaudio-threaded-read
+	# install -D -m 644 etc/asl3-oss.conf  debian/tmp/etc/modules-load.d/asl3-oss.conf
 	install -D -m 644 etc/90-asl3.rules debian/tmp/etc/udev/rules.d/90-asl3.rules
 	install -D -m 644 debian/asterisk.logrotate debian/tmp/etc/logrotate.d/asterisk
 	install -D -m 755 contrib/scripts/ast_coredumper debian/tmp/var/lib/asterisk/scripts/ast_coredumper

--- a/debian/rules
+++ b/debian/rules
@@ -389,8 +389,9 @@ execute_after_dh_auto_install:
 		mv -f debian/tmp/usr/share/asterisk/sounds/en/rpt/transceive.ulaw \
 		      debian/tmp/usr/share/asterisk/sounds/en/rpt/tranceive.ulaw; \
 	fi
-	# OSS (/dev/dsp) removed: app_rpt uses PortAudio (ALSA) as of portaudio-threaded-read
-	# install -D -m 644 etc/asl3-oss.conf  debian/tmp/etc/modules-load.d/asl3-oss.conf
+	if grep -Fq '/dev/dsp' channels/chan_simpleusb.c channels/chan_usbradio.c; then \
+		install -D -m 644 etc/asl3-oss.conf debian/tmp/etc/modules-load.d/asl3-oss.conf; \
+	fi
 	install -D -m 644 etc/90-asl3.rules debian/tmp/etc/udev/rules.d/90-asl3.rules
 	install -D -m 644 debian/asterisk.logrotate debian/tmp/etc/logrotate.d/asterisk
 	install -D -m 755 contrib/scripts/ast_coredumper debian/tmp/var/lib/asterisk/scripts/ast_coredumper

--- a/debian/rules
+++ b/debian/rules
@@ -402,6 +402,10 @@ execute_after_dh_auto_install:
 #	&& rm -f $$extra_packs
 
 execute_after_dh_install:
+	if [ -f debian/tmp/etc/modules-load.d/asl3-oss.conf ]; then \
+		install -D -m 644 debian/tmp/etc/modules-load.d/asl3-oss.conf \
+			debian/asl3-asterisk/etc/modules-load.d/asl3-oss.conf; \
+	fi
 	$(RM) -f debian/asl3-asterisk-modules/usr/lib/${DEB_HOST_MULTIARCH}/asterisk/modules/test_*.so
 
 override_dh_installdocs:


### PR DESCRIPTION
## Summary
- Install `etc/asl3-oss.conf` (`snd_pcm_oss` modules-load drop-in) only when the merged `app_rpt` source still references `/dev/dsp` in `chan_simpleusb.c` or `chan_usbradio.c`
- Drop the unconditional `etc/modules-load.d/*.conf` glob from `asl3-asterisk.install` so PortAudio builds do not fail `dh_install` when no modules-load file is staged
- Copy staged `asl3-oss.conf` into the package in `execute_after_dh_install` when present (legacy OSS-based `app_rpt` builds)
- Skip `snd-pcm-oss` modprobe in postinst when `asl3-oss.conf` is not packaged

This keeps `asl3-asterisk` independent of a specific `app_rpt` revision, matching the existing `tranceive` sound-file conditional. OSS config is dropped automatically once the PortAudio migration removes `/dev/dsp` from both USB radio drivers (AllStarLink/app_rpt #1091–1093 stack).

Consolidates the follow-up from #86 per review feedback.

## Test plan
- [ ] `build-asl3 package` with current `app_rpt` (OSS): `/etc/modules-load.d/asl3-oss.conf` present after install
- [ ] `build-asl3 package` with PortAudio `app_rpt`: build succeeds (no `dh_install` glob failure); no `/etc/modules-load.d/asl3-oss.conf`
- [ ] Fresh install (PortAudio build): `snd-pcm-oss` not loaded at configure time
- [ ] `asl3-asterisk-modules` Depends includes `libportaudio2` via shlibdeps
- [ ] USB radio nodes work without `snd-pcm-oss` loaded on PortAudio builds