### PR TITLE
Fix dh_install when PortAudio app_rpt omits asl3-oss.conf

### DIFF
--- a/debian/asl3-asterisk.install
+++ b/debian/asl3-asterisk.install
@@ -12,7 +12,6 @@ usr/share/asterisk/rest-api
 usr/share/asterisk/moh
 usr/share/asterisk/sounds
 usr/share/dahdi/span_config.d/50-asterisk
-etc/modules-load.d/*.conf
 etc/udev/rules.d/*.rules
 var/lib/asterisk/scripts/*
 var/spool/asterisk/voicemail/*

--- a/debian/asl3-asterisk.install
+++ b/debian/asl3-asterisk.install
@@ -12,6 +12,7 @@ usr/share/asterisk/rest-api
 usr/share/asterisk/moh
 usr/share/asterisk/sounds
 usr/share/dahdi/span_config.d/50-asterisk
+etc/modules-load.d/*.conf
 etc/udev/rules.d/*.rules
 var/lib/asterisk/scripts/*
 var/spool/asterisk/voicemail/*

--- a/debian/asl3-asterisk.postinst
+++ b/debian/asl3-asterisk.postinst
@@ -89,8 +89,10 @@ case "$1" in
 			2>/dev/null
 	done
 
-	# load the modules we care about
-	modprobe -aq snd-pcm-oss
+	# load OSS module when this package ships asl3-oss.conf (OSS-based app_rpt)
+	if [ -f /etc/modules-load.d/asl3-oss.conf ]; then
+		modprobe -aq snd-pcm-oss
+	fi
 
 	# remove customized /etc/systemd/system/asterisk.service
 	test -f /etc/systemd/system/asterisk.service && \

--- a/debian/rules
+++ b/debian/rules
@@ -389,7 +389,8 @@ execute_after_dh_auto_install:
 		mv -f debian/tmp/usr/share/asterisk/sounds/en/rpt/transceive.ulaw \
 		      debian/tmp/usr/share/asterisk/sounds/en/rpt/tranceive.ulaw; \
 	fi
-	install -D -m 644 etc/asl3-oss.conf  debian/tmp/etc/modules-load.d/asl3-oss.conf
+	# OSS (/dev/dsp) removed: app_rpt uses PortAudio (ALSA) as of portaudio-threaded-read
+	# install -D -m 644 etc/asl3-oss.conf  debian/tmp/etc/modules-load.d/asl3-oss.conf
 	install -D -m 644 etc/90-asl3.rules debian/tmp/etc/udev/rules.d/90-asl3.rules
 	install -D -m 644 debian/asterisk.logrotate debian/tmp/etc/logrotate.d/asterisk
 	install -D -m 755 contrib/scripts/ast_coredumper debian/tmp/var/lib/asterisk/scripts/ast_coredumper

--- a/debian/rules
+++ b/debian/rules
@@ -389,8 +389,9 @@ execute_after_dh_auto_install:
 		mv -f debian/tmp/usr/share/asterisk/sounds/en/rpt/transceive.ulaw \
 		      debian/tmp/usr/share/asterisk/sounds/en/rpt/tranceive.ulaw; \
 	fi
-	# OSS (/dev/dsp) removed: app_rpt uses PortAudio (ALSA) as of portaudio-threaded-read
-	# install -D -m 644 etc/asl3-oss.conf  debian/tmp/etc/modules-load.d/asl3-oss.conf
+	if grep -Fq '/dev/dsp' channels/chan_simpleusb.c channels/chan_usbradio.c; then \
+		install -D -m 644 etc/asl3-oss.conf debian/tmp/etc/modules-load.d/asl3-oss.conf; \
+	fi
 	install -D -m 644 etc/90-asl3.rules debian/tmp/etc/udev/rules.d/90-asl3.rules
 	install -D -m 644 debian/asterisk.logrotate debian/tmp/etc/logrotate.d/asterisk
 	install -D -m 755 contrib/scripts/ast_coredumper debian/tmp/var/lib/asterisk/scripts/ast_coredumper

--- a/debian/rules
+++ b/debian/rules
@@ -402,6 +402,10 @@ execute_after_dh_auto_install:
 #	&& rm -f $$extra_packs
 
 execute_after_dh_install:
+	if [ -f debian/tmp/etc/modules-load.d/asl3-oss.conf ]; then \
+		install -D -m 644 debian/tmp/etc/modules-load.d/asl3-oss.conf \
+			debian/asl3-asterisk/etc/modules-load.d/asl3-oss.conf; \
+	fi
 	$(RM) -f debian/asl3-asterisk-modules/usr/lib/${DEB_HOST_MULTIARCH}/asterisk/modules/test_*.so
 
 override_dh_installdocs:


### PR DESCRIPTION
## Summary

Follow-up to #85 — please merge **after** #85 lands.

When `app_rpt` is built with PortAudio (no `/dev/dsp` in `chan_simpleusb` / `chan_usbradio`), `debian/rules` correctly skips staging `asl3-oss.conf`, but `debian/asl3-asterisk.install` still lists `etc/modules-load.d/*.conf`. `dh_install` then aborts because the glob has no matches.

This PR removes the unconditional install glob and copies `asl3-oss.conf` into the package in `execute_after_dh_install` only when it was staged (legacy OSS-based `app_rpt` builds).

**Scope for review:** commit `e51ff4a` only. Earlier commits in this branch are the already-approved #85 work.

## Changes (`e51ff4a`)

- `debian/asl3-asterisk.install`: drop `etc/modules-load.d/*.conf` glob
- `debian/rules`: install staged `asl3-oss.conf` into `debian/asl3-asterisk` when present

## Test plan

- [x] Built `asl3-asterisk` `-104` on crazytrain (arm64) with PortAudio + gpsd `app_rpt` — all debs produced
- [x] Verified `asl3-oss.conf` absent on PortAudio install
- [ ] Confirm legacy OSS `app_rpt` builds still ship `asl3-oss.conf` and load `snd_pcm_oss`